### PR TITLE
feat: implement copy/paste/cut with connection support (#16)

### DIFF
--- a/src/hooks/use-canvas-keyboard.test.ts
+++ b/src/hooks/use-canvas-keyboard.test.ts
@@ -107,6 +107,39 @@ describe('canvas keyboard shortcuts (store-level)', () => {
 		});
 	});
 
+	it('Ctrl+C copies selected elements', () => {
+		const store = useSceneStore.getState();
+		store.addElement(makeElement({ id: 'el-1' }));
+		store.selectElement('el-1');
+		store.copySelected();
+
+		expect(useSceneStore.getState().clipboard).toHaveLength(1);
+		expect(useSceneStore.getState().clipboard[0]?.id).toBe('el-1');
+	});
+
+	it('Ctrl+V pastes clipboard elements', () => {
+		const store = useSceneStore.getState();
+		store.addElement(makeElement({ id: 'el-1', position: { x: 0, y: 0 } }));
+		store.selectElement('el-1');
+		store.copySelected();
+		store.paste();
+
+		const state = useSceneStore.getState();
+		expect(state.elementIds).toHaveLength(2);
+	});
+
+	it('Ctrl+X cuts selected elements (copy + delete)', () => {
+		const store = useSceneStore.getState();
+		store.addElement(makeElement({ id: 'el-1' }));
+		store.selectElement('el-1');
+		store.cutSelected();
+
+		const state = useSceneStore.getState();
+		expect(state.clipboard).toHaveLength(1);
+		expect(state.elements['el-1']).toBeUndefined();
+		expect(state.elementIds).toHaveLength(0);
+	});
+
 	it('Ctrl+Z undoes the last action', () => {
 		const store = useSceneStore.getState();
 		store.addElement(makeElement({ id: 'el-undo', position: { x: 10, y: 20 } }));

--- a/src/hooks/use-canvas-keyboard.ts
+++ b/src/hooks/use-canvas-keyboard.ts
@@ -16,6 +16,9 @@ export type OnSelectionChange = () => void;
  * Shortcuts:
  *   Ctrl/Cmd+Z        — undo
  *   Ctrl/Cmd+Shift+Z  — redo
+ *   Ctrl/Cmd+C        — copy selected
+ *   Ctrl/Cmd+V        — paste clipboard
+ *   Ctrl/Cmd+X        — cut selected
  *   Delete/Backspace  — delete selected elements
  *   Ctrl/Cmd+A        — select all
  *   Ctrl/Cmd+D        — duplicate selected
@@ -69,6 +72,35 @@ export function useCanvasKeyboard(
 					if (isMod) {
 						e.preventDefault();
 						store.selectAll();
+						onSelectionChange?.();
+					}
+					break;
+				}
+
+				case 'c':
+				case 'C': {
+					if (isMod) {
+						e.preventDefault();
+						store.copySelected();
+					}
+					break;
+				}
+
+				case 'v':
+				case 'V': {
+					if (isMod) {
+						e.preventDefault();
+						store.paste();
+						onSelectionChange?.();
+					}
+					break;
+				}
+
+				case 'x':
+				case 'X': {
+					if (isMod) {
+						e.preventDefault();
+						store.cutSelected();
 						onSelectionChange?.();
 					}
 					break;

--- a/src/lib/stores/history-store.ts
+++ b/src/lib/stores/history-store.ts
@@ -43,6 +43,7 @@ function extractSceneState(): SceneState {
 		connectionIds: s.connectionIds,
 		selectedIds: s.selectedIds,
 		clipboard: s.clipboard,
+		clipboardConnections: s.clipboardConnections,
 		camera: s.camera,
 	};
 }


### PR DESCRIPTION
## Summary
- Add `Ctrl+C` / `Ctrl+V` / `Ctrl+X` keyboard shortcuts to canvas
- Add `cutSelected()` store action (copy + delete in sequence)
- Enhance `copySelected()` to capture connections between selected elements
- Enhance `paste()` to remap element & connection IDs and auto-select pasted elements
- Add `clipboardConnections` to SceneState for connection-aware clipboard

## Key Design Decisions
- **Connection-aware clipboard**: Only connections where both endpoints are selected get copied — partial connections are excluded
- **ID remapping**: `paste()` builds an `idMap` (old → new) and remaps connection endpoints, preventing dangling references
- **Auto-selection**: Pasted elements are automatically selected, matching standard editor UX (Figma, Photoshop, etc.)
- **Cut = copy + delete**: Two separate undoable operations, so Ctrl+Z after cut restores elements

## Files Changed
| File | Change |
|------|--------|
| `src/lib/stores/scene-store.ts` | Add `clipboardConnections`, `cutSelected`, enhance `copySelected` and `paste` |
| `src/lib/stores/scene-store.test.ts` | 7 new tests for connections, cut, auto-select |
| `src/lib/stores/history-store.ts` | Include `clipboardConnections` in state extraction |
| `src/hooks/use-canvas-keyboard.ts` | Add Ctrl+C/V/X bindings |
| `src/hooks/use-canvas-keyboard.test.ts` | 3 new tests for keyboard shortcuts |

## Test plan
- [x] 33 scene store tests pass (7 new)
- [x] 11 keyboard hook tests pass (3 new)
- [x] All 438 tests pass across 26 test files
- [x] Biome check clean
- [x] TypeScript compiles with no errors

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)