### PR TITLE
feat: implement canvas rulers along top and left edges (#19)

### DIFF
--- a/src/components/canvas/canvas-ruler.tsx
+++ b/src/components/canvas/canvas-ruler.tsx
@@ -1,0 +1,72 @@
+'use client';
+
+import { useCallback, useEffect, useRef } from 'react';
+import { RulerRenderer } from '@/lib/pixi/ruler-renderer';
+import { useSceneStore } from '@/lib/stores/scene-store';
+
+const RULER_SIZE = 24;
+const BACKGROUND_COLOR = 0x1e1e2e;
+const TICK_COLOR = 0x666666;
+const LABEL_COLOR = '#999999';
+const CURSOR_COLOR = 0xff4444;
+
+const rendererInstance = new RulerRenderer();
+
+export function CanvasRuler({
+	orientation,
+	cursorPosition,
+}: {
+	orientation: 'horizontal' | 'vertical';
+	cursorPosition: number | null;
+}) {
+	const canvasRef = useRef<HTMLCanvasElement>(null);
+	const camera = useSceneStore((s) => s.camera);
+
+	const draw = useCallback(() => {
+		const canvas = canvasRef.current;
+		if (!canvas) return;
+
+		const ctx = canvas.getContext('2d');
+		if (!ctx) return;
+
+		const dpr = window.devicePixelRatio || 1;
+		const rect = canvas.getBoundingClientRect();
+		const length = orientation === 'horizontal' ? rect.width : rect.height;
+
+		// Size canvas to match CSS size at native resolution
+		const w = orientation === 'horizontal' ? length * dpr : RULER_SIZE * dpr;
+		const h = orientation === 'horizontal' ? RULER_SIZE * dpr : length * dpr;
+
+		if (canvas.width !== w || canvas.height !== h) {
+			canvas.width = w;
+			canvas.height = h;
+		}
+
+		ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+
+		rendererInstance.render(ctx, {
+			orientation,
+			length,
+			rulerSize: RULER_SIZE,
+			cameraX: camera.x,
+			cameraY: camera.y,
+			zoom: camera.zoom,
+			cursorPosition,
+			backgroundColor: BACKGROUND_COLOR,
+			tickColor: TICK_COLOR,
+			labelColor: LABEL_COLOR,
+			cursorColor: CURSOR_COLOR,
+		});
+	}, [orientation, camera, cursorPosition]);
+
+	useEffect(() => {
+		draw();
+	}, [draw]);
+
+	const style =
+		orientation === 'horizontal'
+			? { height: `${RULER_SIZE}px`, width: '100%' }
+			: { width: `${RULER_SIZE}px`, height: '100%' };
+
+	return <canvas ref={canvasRef} style={style} className="pointer-events-none" />;
+}

--- a/src/lib/pixi/ruler-renderer.test.ts
+++ b/src/lib/pixi/ruler-renderer.test.ts
@@ -1,0 +1,196 @@
+import { describe, expect, it, vi } from 'vitest';
+import type { RulerRenderOptions } from './ruler-renderer';
+import { RulerRenderer } from './ruler-renderer';
+
+function createMockContext() {
+	return {
+		clearRect: vi.fn(),
+		fillRect: vi.fn(),
+		fillText: vi.fn(),
+		beginPath: vi.fn(),
+		moveTo: vi.fn(),
+		lineTo: vi.fn(),
+		stroke: vi.fn(),
+		save: vi.fn(),
+		restore: vi.fn(),
+		translate: vi.fn(),
+		rotate: vi.fn(),
+		fillStyle: '',
+		strokeStyle: '',
+		lineWidth: 1,
+		font: '',
+		textAlign: '' as CanvasTextAlign,
+		textBaseline: '' as CanvasTextBaseline,
+	} as unknown as CanvasRenderingContext2D;
+}
+
+function baseOptions(overrides: Partial<RulerRenderOptions> = {}): RulerRenderOptions {
+	return {
+		orientation: 'horizontal',
+		length: 800,
+		rulerSize: 24,
+		cameraX: 0,
+		cameraY: 0,
+		zoom: 1,
+		cursorPosition: null,
+		backgroundColor: 0x1e1e2e,
+		tickColor: 0x666666,
+		labelColor: '#999999',
+		cursorColor: 0xff4444,
+		...overrides,
+	};
+}
+
+describe('RulerRenderer', () => {
+	describe('getNiceInterval', () => {
+		it('returns ~100 world units at zoom 1', () => {
+			const renderer = new RulerRenderer();
+			const interval = renderer.getNiceInterval(1);
+			expect(interval).toBe(100);
+		});
+
+		it('returns smaller interval at zoom 2 (more detail)', () => {
+			const renderer = new RulerRenderer();
+			const interval = renderer.getNiceInterval(2);
+			expect(interval).toBeLessThan(100);
+			expect(interval).toBeGreaterThan(0);
+		});
+
+		it('returns larger interval at zoom 0.5 (less detail)', () => {
+			const renderer = new RulerRenderer();
+			const interval = renderer.getNiceInterval(0.5);
+			expect(interval).toBeGreaterThan(100);
+		});
+
+		it('returns a nice number (1, 2, 5, 10, 20, 50, 100, ...)', () => {
+			const renderer = new RulerRenderer();
+			const niceValues = [1, 2, 5, 10, 20, 50, 100, 200, 500, 1000, 2000, 5000];
+			for (const zoom of [0.1, 0.25, 0.5, 1, 2, 4, 8]) {
+				const interval = renderer.getNiceInterval(zoom);
+				expect(niceValues).toContain(interval);
+			}
+		});
+
+		it('ensures screen spacing is between 50 and 200 pixels', () => {
+			const renderer = new RulerRenderer();
+			for (const zoom of [0.1, 0.2, 0.5, 1, 2, 5, 10]) {
+				const interval = renderer.getNiceInterval(zoom);
+				const screenSpacing = interval * zoom;
+				expect(screenSpacing).toBeGreaterThanOrEqual(50);
+				expect(screenSpacing).toBeLessThanOrEqual(500);
+			}
+		});
+	});
+
+	describe('render horizontal', () => {
+		it('clears the canvas', () => {
+			const ctx = createMockContext();
+			const renderer = new RulerRenderer();
+			renderer.render(ctx, baseOptions());
+			expect(ctx.clearRect).toHaveBeenCalledWith(0, 0, 800, 24);
+		});
+
+		it('draws background fill', () => {
+			const ctx = createMockContext();
+			const renderer = new RulerRenderer();
+			renderer.render(ctx, baseOptions());
+			expect(ctx.fillRect).toHaveBeenCalled();
+		});
+
+		it('draws tick lines', () => {
+			const ctx = createMockContext();
+			const renderer = new RulerRenderer();
+			renderer.render(ctx, baseOptions());
+			expect(ctx.moveTo).toHaveBeenCalled();
+			expect(ctx.lineTo).toHaveBeenCalled();
+			expect(ctx.stroke).toHaveBeenCalled();
+		});
+
+		it('draws labels for major ticks', () => {
+			const ctx = createMockContext();
+			const renderer = new RulerRenderer();
+			renderer.render(ctx, baseOptions());
+			expect(ctx.fillText).toHaveBeenCalled();
+			// Check that labels contain numeric values
+			const labelCalls = (ctx.fillText as ReturnType<typeof vi.fn>).mock.calls;
+			for (const call of labelCalls) {
+				expect(typeof call[0]).toBe('string');
+				expect(Number.isFinite(Number(call[0]))).toBe(true);
+			}
+		});
+
+		it('draws cursor indicator when cursorPosition is set', () => {
+			const ctx = createMockContext();
+			const renderer = new RulerRenderer();
+			renderer.render(ctx, baseOptions({ cursorPosition: 400 }));
+			// Should draw at least one more line for the cursor
+			const moveToCallsWithCursor = (ctx.moveTo as ReturnType<typeof vi.fn>).mock.calls;
+			expect(moveToCallsWithCursor.length).toBeGreaterThan(0);
+		});
+
+		it('does not draw cursor indicator when cursorPosition is null', () => {
+			const ctxWith = createMockContext();
+			const ctxWithout = createMockContext();
+			const renderer = new RulerRenderer();
+			renderer.render(ctxWith, baseOptions({ cursorPosition: 200 }));
+			renderer.render(ctxWithout, baseOptions({ cursorPosition: null }));
+			// The version with cursor should have more drawing calls
+			const withCalls = (ctxWith.moveTo as ReturnType<typeof vi.fn>).mock.calls.length;
+			const withoutCalls = (ctxWithout.moveTo as ReturnType<typeof vi.fn>).mock.calls.length;
+			expect(withCalls).toBeGreaterThan(withoutCalls);
+		});
+	});
+
+	describe('render vertical', () => {
+		it('clears with correct dimensions', () => {
+			const ctx = createMockContext();
+			const renderer = new RulerRenderer();
+			renderer.render(ctx, baseOptions({ orientation: 'vertical', length: 600 }));
+			expect(ctx.clearRect).toHaveBeenCalledWith(0, 0, 24, 600);
+		});
+
+		it('draws tick lines and labels', () => {
+			const ctx = createMockContext();
+			const renderer = new RulerRenderer();
+			renderer.render(ctx, baseOptions({ orientation: 'vertical', length: 600 }));
+			expect(ctx.moveTo).toHaveBeenCalled();
+			expect(ctx.lineTo).toHaveBeenCalled();
+			expect(ctx.fillText).toHaveBeenCalled();
+		});
+	});
+
+	describe('camera offset', () => {
+		it('shifts tick positions based on camera X for horizontal ruler', () => {
+			const ctx1 = createMockContext();
+			const ctx2 = createMockContext();
+			const renderer = new RulerRenderer();
+			renderer.render(ctx1, baseOptions({ cameraX: 0 }));
+			renderer.render(ctx2, baseOptions({ cameraX: 200 }));
+
+			// Labels should be different because camera moved
+			const labels1 = (ctx1.fillText as ReturnType<typeof vi.fn>).mock.calls.map(
+				(c: string[]) => c[0],
+			);
+			const labels2 = (ctx2.fillText as ReturnType<typeof vi.fn>).mock.calls.map(
+				(c: string[]) => c[0],
+			);
+			expect(labels1).not.toEqual(labels2);
+		});
+
+		it('shifts tick positions based on camera Y for vertical ruler', () => {
+			const ctx1 = createMockContext();
+			const ctx2 = createMockContext();
+			const renderer = new RulerRenderer();
+			renderer.render(ctx1, baseOptions({ orientation: 'vertical', cameraY: 0, length: 600 }));
+			renderer.render(ctx2, baseOptions({ orientation: 'vertical', cameraY: 200, length: 600 }));
+
+			const labels1 = (ctx1.fillText as ReturnType<typeof vi.fn>).mock.calls.map(
+				(c: string[]) => c[0],
+			);
+			const labels2 = (ctx2.fillText as ReturnType<typeof vi.fn>).mock.calls.map(
+				(c: string[]) => c[0],
+			);
+			expect(labels1).not.toEqual(labels2);
+		});
+	});
+});

--- a/src/lib/pixi/ruler-renderer.ts
+++ b/src/lib/pixi/ruler-renderer.ts
@@ -1,0 +1,202 @@
+/**
+ * Canvas rulers along top and left edges of the canvas workspace.
+ * Renders tick marks with numeric labels that adapt to zoom level.
+ *
+ * Uses Canvas 2D (not Pixi.js) since rulers are UI chrome rendered
+ * at fixed screen positions with crisp text.
+ *
+ * Spec reference: Section 6.1 (rulers along top/left edges)
+ */
+
+export interface RulerRenderOptions {
+	orientation: 'horizontal' | 'vertical';
+	length: number;
+	rulerSize: number;
+	cameraX: number;
+	cameraY: number;
+	zoom: number;
+	cursorPosition: number | null;
+	backgroundColor: number;
+	tickColor: number;
+	labelColor: string;
+	cursorColor: number;
+}
+
+/** "Nice" multipliers for human-friendly ruler intervals */
+const NICE_MULTIPLIERS = [1, 2, 5];
+
+/** Target screen spacing for major ticks (pixels) */
+const TARGET_SPACING = 100;
+
+function hexToCSS(hex: number): string {
+	return `#${hex.toString(16).padStart(6, '0')}`;
+}
+
+export class RulerRenderer {
+	/**
+	 * Compute a "nice" tick interval in world units for the given zoom level.
+	 * Returns values from the sequence 1, 2, 5, 10, 20, 50, 100, ...
+	 * such that the screen spacing is close to TARGET_SPACING pixels.
+	 */
+	getNiceInterval(zoom: number): number {
+		const rawInterval = TARGET_SPACING / zoom;
+		const magnitude = 10 ** Math.floor(Math.log10(rawInterval));
+
+		let best = magnitude;
+		let bestDiff = Math.abs(magnitude * zoom - TARGET_SPACING);
+
+		for (const m of NICE_MULTIPLIERS) {
+			const candidate = magnitude * m;
+			const diff = Math.abs(candidate * zoom - TARGET_SPACING);
+			if (diff < bestDiff) {
+				best = candidate;
+				bestDiff = diff;
+			}
+		}
+
+		// Also check the next magnitude up
+		for (const m of NICE_MULTIPLIERS) {
+			const candidate = magnitude * 10 * m;
+			const diff = Math.abs(candidate * zoom - TARGET_SPACING);
+			if (diff < bestDiff) {
+				best = candidate;
+				bestDiff = diff;
+			}
+		}
+
+		return best;
+	}
+
+	render(ctx: CanvasRenderingContext2D, options: RulerRenderOptions): void {
+		const { orientation, length, rulerSize } = options;
+
+		const w = orientation === 'horizontal' ? length : rulerSize;
+		const h = orientation === 'horizontal' ? rulerSize : length;
+
+		ctx.clearRect(0, 0, w, h);
+
+		// Background
+		ctx.fillStyle = hexToCSS(options.backgroundColor);
+		ctx.fillRect(0, 0, w, h);
+
+		// Ticks and labels
+		const majorInterval = this.getNiceInterval(options.zoom);
+		const minorInterval = majorInterval / 5;
+
+		if (orientation === 'horizontal') {
+			this.renderHorizontal(ctx, options, majorInterval, minorInterval);
+		} else {
+			this.renderVertical(ctx, options, majorInterval, minorInterval);
+		}
+
+		// Cursor indicator
+		if (options.cursorPosition !== null) {
+			this.renderCursor(ctx, options);
+		}
+	}
+
+	private renderHorizontal(
+		ctx: CanvasRenderingContext2D,
+		options: RulerRenderOptions,
+		majorInterval: number,
+		minorInterval: number,
+	): void {
+		const { length, rulerSize, cameraX, zoom, tickColor, labelColor } = options;
+
+		// World range visible in the ruler
+		const worldStart = -cameraX / zoom;
+		const worldEnd = (length - cameraX) / zoom;
+
+		// Align to minor interval boundaries
+		const firstTick = Math.floor(worldStart / minorInterval) * minorInterval;
+
+		ctx.strokeStyle = hexToCSS(tickColor);
+		ctx.lineWidth = 1;
+		ctx.font = '10px sans-serif';
+		ctx.textAlign = 'center';
+		ctx.textBaseline = 'top';
+		ctx.fillStyle = labelColor;
+
+		ctx.beginPath();
+
+		for (let world = firstTick; world <= worldEnd; world += minorInterval) {
+			const screen = world * zoom + cameraX;
+			if (screen < 0 || screen > length) continue;
+
+			const isMajor = Math.abs(world % majorInterval) < minorInterval * 0.5;
+			const tickHeight = isMajor ? rulerSize * 0.5 : rulerSize * 0.25;
+
+			ctx.moveTo(screen, rulerSize);
+			ctx.lineTo(screen, rulerSize - tickHeight);
+
+			if (isMajor) {
+				ctx.fillText(String(Math.round(world)), screen, 2);
+			}
+		}
+
+		ctx.stroke();
+	}
+
+	private renderVertical(
+		ctx: CanvasRenderingContext2D,
+		options: RulerRenderOptions,
+		majorInterval: number,
+		minorInterval: number,
+	): void {
+		const { length, rulerSize, cameraY, zoom, tickColor, labelColor } = options;
+
+		const worldStart = -cameraY / zoom;
+		const worldEnd = (length - cameraY) / zoom;
+
+		const firstTick = Math.floor(worldStart / minorInterval) * minorInterval;
+
+		ctx.strokeStyle = hexToCSS(tickColor);
+		ctx.lineWidth = 1;
+		ctx.font = '10px sans-serif';
+		ctx.fillStyle = labelColor;
+
+		ctx.beginPath();
+
+		for (let world = firstTick; world <= worldEnd; world += minorInterval) {
+			const screen = world * zoom + cameraY;
+			if (screen < 0 || screen > length) continue;
+
+			const isMajor = Math.abs(world % majorInterval) < minorInterval * 0.5;
+			const tickWidth = isMajor ? rulerSize * 0.5 : rulerSize * 0.25;
+
+			ctx.moveTo(rulerSize, screen);
+			ctx.lineTo(rulerSize - tickWidth, screen);
+
+			if (isMajor) {
+				ctx.save();
+				ctx.translate(rulerSize * 0.4, screen);
+				ctx.rotate(-Math.PI / 2);
+				ctx.textAlign = 'center';
+				ctx.textBaseline = 'bottom';
+				ctx.fillText(String(Math.round(world)), 0, 0);
+				ctx.restore();
+			}
+		}
+
+		ctx.stroke();
+	}
+
+	private renderCursor(ctx: CanvasRenderingContext2D, options: RulerRenderOptions): void {
+		const { orientation, rulerSize, cursorPosition, cursorColor } = options;
+		if (cursorPosition === null) return;
+
+		ctx.strokeStyle = hexToCSS(cursorColor);
+		ctx.lineWidth = 1;
+		ctx.beginPath();
+
+		if (orientation === 'horizontal') {
+			ctx.moveTo(cursorPosition, 0);
+			ctx.lineTo(cursorPosition, rulerSize);
+		} else {
+			ctx.moveTo(0, cursorPosition);
+			ctx.lineTo(rulerSize, cursorPosition);
+		}
+
+		ctx.stroke();
+	}
+}


### PR DESCRIPTION
## Summary
- Add `RulerRenderer` class — pure Canvas 2D logic for drawing tick marks and numeric labels
- Add `CanvasRuler` React component — subscribes to Zustand camera state, renders rulers
- Integrate rulers into `PixiCanvas` with horizontal (top) and vertical (left) rulers
- Cursor position tracking with red indicator line on both rulers
- Corner dead zone where rulers meet (blank square)
- Dynamic tick scaling: "nice number" algorithm (1, 2, 5, 10, 20, 50, 100...) keeps major ticks 50-200px apart at any zoom level

## Architecture
| Layer | Component | Purpose |
|-------|-----------|---------|
| Logic | `RulerRenderer` | Pure computation + Canvas 2D drawing (testable) |
| View | `CanvasRuler` | React wrapper, reads camera from Zustand |
| Integration | `PixiCanvas` | Mounts rulers as HTML overlays, tracks cursor |

## Files Changed
| File | Change |
|------|--------|
| `src/lib/pixi/ruler-renderer.ts` | **New** — RulerRenderer class |
| `src/lib/pixi/ruler-renderer.test.ts` | **New** — 15 unit tests |
| `src/components/canvas/canvas-ruler.tsx` | **New** — React ruler component |
| `src/components/canvas/pixi-canvas.tsx` | Integrate rulers + cursor tracking |

## Test plan
- [x] 15 ruler renderer tests pass (intervals, drawing, camera offset, cursor)
- [x] All 453 tests pass across 27 test files
- [x] Biome check clean
- [x] TypeScript compiles with no errors

Closes #19

🤖 Generated with [Claude Code](https://claude.com/claude-code)