### PR TITLE
feat: build resizable panel layout system (#9)

### DIFF
--- a/src/components/editor/editor-layout.test.tsx
+++ b/src/components/editor/editor-layout.test.tsx
@@ -1,0 +1,178 @@
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useUIStore } from '@/lib/stores/ui-store';
+import { EditorLayout } from './editor-layout';
+
+// Mock child components to isolate layout behavior
+vi.mock('@/components/canvas/pixi-canvas', () => ({
+	PixiCanvas: () => <div data-testid="pixi-canvas">Canvas</div>,
+}));
+vi.mock('@/components/panels/left-panel', () => ({
+	LeftPanel: () => <div data-testid="left-panel-content">Left</div>,
+}));
+vi.mock('@/components/panels/right-panel', () => ({
+	RightPanel: () => <div data-testid="right-panel-content">Right</div>,
+}));
+vi.mock('@/components/panels/bottom-panel', () => ({
+	BottomPanel: () => <div data-testid="bottom-panel-content">Bottom</div>,
+}));
+vi.mock('./toolbar', () => ({
+	Toolbar: () => <div data-testid="toolbar">Toolbar</div>,
+}));
+
+// react-resizable-panels requires ResizeObserver
+class MockResizeObserver {
+	observe = vi.fn();
+	unobserve = vi.fn();
+	disconnect = vi.fn();
+}
+vi.stubGlobal('ResizeObserver', MockResizeObserver);
+
+describe('EditorLayout', () => {
+	beforeEach(() => {
+		useUIStore.getState().reset();
+	});
+
+	afterEach(() => {
+		cleanup();
+		useUIStore.getState().reset();
+	});
+
+	describe('rendering', () => {
+		it('renders the toolbar', () => {
+			render(<EditorLayout />);
+			expect(screen.getByTestId('toolbar')).toBeDefined();
+		});
+
+		it('renders the canvas area', () => {
+			render(<EditorLayout />);
+			expect(screen.getByTestId('pixi-canvas')).toBeDefined();
+		});
+
+		it('renders left panel', () => {
+			render(<EditorLayout />);
+			expect(screen.getByTestId('left-panel-content')).toBeDefined();
+		});
+
+		it('renders right panel', () => {
+			render(<EditorLayout />);
+			expect(screen.getByTestId('right-panel-content')).toBeDefined();
+		});
+
+		it('renders bottom panel', () => {
+			render(<EditorLayout />);
+			expect(screen.getByTestId('bottom-panel-content')).toBeDefined();
+		});
+	});
+
+	describe('store integration — panel sizes', () => {
+		it('reads initial panel sizes from the UI store', () => {
+			const { panelSizes } = useUIStore.getState();
+			render(<EditorLayout />);
+			// Default sizes from store: left=18, right=20, bottom=35
+			expect(panelSizes.left).toBe(18);
+			expect(panelSizes.right).toBe(20);
+			expect(panelSizes.bottom).toBe(35);
+		});
+
+		it('uses custom panel sizes from store', () => {
+			useUIStore.getState().setPanelSize('left', 25);
+			const { panelSizes } = useUIStore.getState();
+			expect(panelSizes.left).toBe(25);
+		});
+	});
+
+	describe('store integration — panel visibility', () => {
+		it('syncs left panel visibility toggle to store', () => {
+			useUIStore.getState().togglePanel('left');
+			expect(useUIStore.getState().panels.left).toBe(false);
+		});
+
+		it('syncs right panel visibility toggle to store', () => {
+			useUIStore.getState().togglePanel('right');
+			expect(useUIStore.getState().panels.right).toBe(false);
+		});
+
+		it('syncs bottom panel visibility toggle to store', () => {
+			useUIStore.getState().togglePanel('bottom');
+			expect(useUIStore.getState().panels.bottom).toBe(false);
+		});
+	});
+
+	describe('keyboard shortcuts for panel toggle', () => {
+		it('Ctrl+B toggles left panel visibility', () => {
+			render(<EditorLayout />);
+			expect(useUIStore.getState().panels.left).toBe(true);
+
+			act(() => {
+				fireEvent.keyDown(document, { key: 'b', ctrlKey: true });
+			});
+			expect(useUIStore.getState().panels.left).toBe(false);
+
+			act(() => {
+				fireEvent.keyDown(document, { key: 'b', ctrlKey: true });
+			});
+			expect(useUIStore.getState().panels.left).toBe(true);
+		});
+
+		it('Ctrl+I toggles right panel visibility', () => {
+			render(<EditorLayout />);
+			expect(useUIStore.getState().panels.right).toBe(true);
+
+			act(() => {
+				fireEvent.keyDown(document, { key: 'i', ctrlKey: true });
+			});
+			expect(useUIStore.getState().panels.right).toBe(false);
+		});
+
+		it('Ctrl+` toggles bottom panel visibility', () => {
+			render(<EditorLayout />);
+			expect(useUIStore.getState().panels.bottom).toBe(true);
+
+			act(() => {
+				fireEvent.keyDown(document, { key: '`', ctrlKey: true });
+			});
+			expect(useUIStore.getState().panels.bottom).toBe(false);
+		});
+
+		it('Cmd+B toggles left panel on Mac', () => {
+			render(<EditorLayout />);
+			act(() => {
+				fireEvent.keyDown(document, { key: 'b', metaKey: true });
+			});
+			expect(useUIStore.getState().panels.left).toBe(false);
+		});
+
+		it('does not toggle panels without modifier key', () => {
+			render(<EditorLayout />);
+			act(() => {
+				fireEvent.keyDown(document, { key: 'b' });
+			});
+			expect(useUIStore.getState().panels.left).toBe(true);
+		});
+	});
+
+	describe('layout structure', () => {
+		it('has correct flex column layout', () => {
+			const { container } = render(<EditorLayout />);
+			const outerDiv = container.firstElementChild;
+			expect(outerDiv?.className).toContain('flex');
+			expect(outerDiv?.className).toContain('flex-col');
+			expect(outerDiv?.className).toContain('h-screen');
+		});
+	});
+
+	describe('cleanup', () => {
+		it('keyboard shortcuts stop working after unmount', () => {
+			const { unmount } = render(<EditorLayout />);
+			unmount();
+
+			// After unmount, keyboard shortcuts should have no effect
+			act(() => {
+				fireEvent.keyDown(document, { key: 'b', ctrlKey: true });
+			});
+			// Panel should still be true (default) since handler was removed
+			expect(useUIStore.getState().panels.left).toBe(true);
+		});
+	});
+});

--- a/src/components/editor/editor-layout.tsx
+++ b/src/components/editor/editor-layout.tsx
@@ -1,23 +1,118 @@
 'use client';
 
+import { useCallback, useEffect } from 'react';
+import type { PanelSize } from 'react-resizable-panels';
+import { usePanelRef } from 'react-resizable-panels';
 import { PixiCanvas } from '@/components/canvas/pixi-canvas';
 import { BottomPanel } from '@/components/panels/bottom-panel';
 import { LeftPanel } from '@/components/panels/left-panel';
 import { RightPanel } from '@/components/panels/right-panel';
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
+import { useUIStore } from '@/lib/stores/ui-store';
 import { Toolbar } from './toolbar';
 
 export function EditorLayout() {
+	const leftRef = usePanelRef();
+	const rightRef = usePanelRef();
+	const bottomRef = usePanelRef();
+
+	const panelSizes = useUIStore((s) => s.panelSizes);
+	const panels = useUIStore((s) => s.panels);
+	const togglePanel = useUIStore((s) => s.togglePanel);
+	const setPanelSize = useUIStore((s) => s.setPanelSize);
+	const setPanelVisible = useUIStore((s) => s.setPanelVisible);
+
+	// Sync imperative panel collapse/expand with store visibility
+	useEffect(() => {
+		const panel = leftRef.current;
+		if (!panel) return;
+		if (panels.left && panel.isCollapsed()) panel.expand();
+		else if (!panels.left && !panel.isCollapsed()) panel.collapse();
+	}, [panels.left, leftRef]);
+
+	useEffect(() => {
+		const panel = rightRef.current;
+		if (!panel) return;
+		if (panels.right && panel.isCollapsed()) panel.expand();
+		else if (!panels.right && !panel.isCollapsed()) panel.collapse();
+	}, [panels.right, rightRef]);
+
+	useEffect(() => {
+		const panel = bottomRef.current;
+		if (!panel) return;
+		if (panels.bottom && panel.isCollapsed()) panel.expand();
+		else if (!panels.bottom && !panel.isCollapsed()) panel.collapse();
+	}, [panels.bottom, bottomRef]);
+
+	// Keyboard shortcuts for panel toggle
+	useEffect(() => {
+		function handleKeyDown(e: KeyboardEvent) {
+			const isMod = e.metaKey || e.ctrlKey;
+			if (!isMod) return;
+
+			switch (e.key) {
+				case 'b':
+				case 'B':
+					e.preventDefault();
+					togglePanel('left');
+					break;
+				case 'i':
+				case 'I':
+					e.preventDefault();
+					togglePanel('right');
+					break;
+				case '`':
+					e.preventDefault();
+					togglePanel('bottom');
+					break;
+			}
+		}
+
+		document.addEventListener('keydown', handleKeyDown);
+		return () => document.removeEventListener('keydown', handleKeyDown);
+	}, [togglePanel]);
+
+	// Track resize and sync collapsed state back to store
+	const handleLeftResize = useCallback(
+		(size: PanelSize) => {
+			setPanelSize('left', size.asPercentage);
+			// Sync collapsed state from drag-to-collapse
+			if (size.asPercentage === 0 && panels.left) setPanelVisible('left', false);
+			else if (size.asPercentage > 0 && !panels.left) setPanelVisible('left', true);
+		},
+		[setPanelSize, setPanelVisible, panels.left],
+	);
+
+	const handleRightResize = useCallback(
+		(size: PanelSize) => {
+			setPanelSize('right', size.asPercentage);
+			if (size.asPercentage === 0 && panels.right) setPanelVisible('right', false);
+			else if (size.asPercentage > 0 && !panels.right) setPanelVisible('right', true);
+		},
+		[setPanelSize, setPanelVisible, panels.right],
+	);
+
+	const handleBottomResize = useCallback(
+		(size: PanelSize) => {
+			setPanelSize('bottom', size.asPercentage);
+			if (size.asPercentage === 0 && panels.bottom) setPanelVisible('bottom', false);
+			else if (size.asPercentage > 0 && !panels.bottom) setPanelVisible('bottom', true);
+		},
+		[setPanelSize, setPanelVisible, panels.bottom],
+	);
+
 	return (
 		<div className="flex h-screen flex-col overflow-hidden">
 			<Toolbar />
 			<ResizablePanelGroup orientation="horizontal" className="flex-1">
 				<ResizablePanel
 					id="left-panel"
-					defaultSize={18}
+					panelRef={leftRef}
+					defaultSize={panelSizes.left}
 					minSize={12}
 					maxSize={28}
 					collapsible
+					onResize={handleLeftResize}
 					className="bg-card"
 				>
 					<LeftPanel />
@@ -25,9 +120,9 @@ export function EditorLayout() {
 
 				<ResizableHandle withHandle />
 
-				<ResizablePanel id="center-panel" defaultSize={58}>
+				<ResizablePanel id="center-panel" defaultSize={100 - panelSizes.left - panelSizes.right}>
 					<ResizablePanelGroup orientation="vertical">
-						<ResizablePanel id="canvas-panel" defaultSize={65} minSize={30}>
+						<ResizablePanel id="canvas-panel" defaultSize={100 - panelSizes.bottom} minSize={30}>
 							<PixiCanvas />
 						</ResizablePanel>
 
@@ -35,10 +130,12 @@ export function EditorLayout() {
 
 						<ResizablePanel
 							id="bottom-panel"
-							defaultSize={35}
+							panelRef={bottomRef}
+							defaultSize={panelSizes.bottom}
 							minSize={10}
 							maxSize={60}
 							collapsible
+							onResize={handleBottomResize}
 							className="bg-card"
 						>
 							<BottomPanel />
@@ -50,10 +147,12 @@ export function EditorLayout() {
 
 				<ResizablePanel
 					id="right-panel"
-					defaultSize={20}
+					panelRef={rightRef}
+					defaultSize={panelSizes.right}
 					minSize={14}
 					maxSize={30}
 					collapsible
+					onResize={handleRightResize}
 					className="bg-card"
 				>
 					<RightPanel />


### PR DESCRIPTION
## Summary
- Wires all three panels (left, right, bottom) to Zustand UI store for persistent sizing and visibility
- Adds keyboard shortcuts: `Ctrl+B` (toggle left panel), `Ctrl+I` (toggle right panel), `Ctrl+`` ` (toggle bottom panel)
- Uses `react-resizable-panels` v4 imperative API (`usePanelRef`, `collapse()`/`expand()`) for programmatic panel control
- Panel `onResize` callbacks sync sizes and collapsed state back to UI store, which persists to IndexedDB via Dexie.js

## Key Design Decisions
- Panel sizes stored as percentages in Zustand (`panelSizes.left`, `.right`, `.bottom`) — matches `react-resizable-panels` native format
- Bidirectional sync: store → panels (keyboard toggle) and panels → store (drag resize/collapse)
- Keyboard handler on `document` (not canvas-specific container) since panel shortcuts are global editor shortcuts
- `useCallback` for resize handlers to prevent unnecessary re-renders during drag

## Test plan
- [x] 17 unit tests covering rendering, store integration, keyboard shortcuts, cleanup
- [x] All 487 tests pass (full suite)
- [x] Biome lint/format clean
- [x] TypeScript strict mode — no errors

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)