### PR TITLE
feat: wire toolbar and tool selector to Zustand stores (#10)

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
 		"@testing-library/dom": "latest",
 		"@testing-library/jest-dom": "latest",
 		"@testing-library/react": "latest",
+		"@testing-library/user-event": "^14.6.1",
 		"@types/node": "^22",
 		"@types/react": "^19",
 		"@types/react-dom": "^19",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -96,6 +96,9 @@ importers:
       '@testing-library/react':
         specifier: latest
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
+      '@testing-library/user-event':
+        specifier: ^14.6.1
+        version: 14.6.1(@testing-library/dom@10.4.1)
       '@types/node':
         specifier: ^22
         version: 22.19.11
@@ -2240,6 +2243,12 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@testing-library/user-event@14.6.1':
+    resolution: {integrity: sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==}
+    engines: {node: '>=12', npm: '>=6'}
+    peerDependencies:
+      '@testing-library/dom': '>=7.21.4'
 
   '@ts-morph/common@0.27.0':
     resolution: {integrity: sha512-Wf29UqxWDpc+i61k3oIOzcUfQt79PIT9y/MWfAGlrkjg6lBC1hwDECLXPVJAhWjiGbfBCxZd65F/LIZF3+jeJQ==}
@@ -6707,6 +6716,10 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.14
       '@types/react-dom': 19.2.3(@types/react@19.2.14)
+
+  '@testing-library/user-event@14.6.1(@testing-library/dom@10.4.1)':
+    dependencies:
+      '@testing-library/dom': 10.4.1
 
   '@ts-morph/common@0.27.0':
     dependencies:

--- a/src/components/editor/tool-selector.test.tsx
+++ b/src/components/editor/tool-selector.test.tsx
@@ -1,0 +1,67 @@
+import { act, cleanup, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { useUIStore } from '@/lib/stores/ui-store';
+import { ToolSelector } from './tool-selector';
+
+function TestWrapper({ children }: { children: ReactNode }) {
+	return <TooltipProvider>{children}</TooltipProvider>;
+}
+
+function renderToolSelector() {
+	return render(<ToolSelector />, { wrapper: TestWrapper });
+}
+
+class MockResizeObserver {
+	observe = vi.fn();
+	unobserve = vi.fn();
+	disconnect = vi.fn();
+}
+vi.stubGlobal('ResizeObserver', MockResizeObserver);
+
+describe('ToolSelector', () => {
+	beforeEach(() => {
+		useUIStore.getState().reset();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('renders all tool buttons', () => {
+		renderToolSelector();
+		expect(screen.getByLabelText('Select')).toBeDefined();
+		expect(screen.getByLabelText('Hand')).toBeDefined();
+		expect(screen.getByLabelText('Rectangle')).toBeDefined();
+		expect(screen.getByLabelText('Ellipse')).toBeDefined();
+		expect(screen.getByLabelText('Text')).toBeDefined();
+		expect(screen.getByLabelText('Arrow')).toBeDefined();
+		expect(screen.getByLabelText('Line')).toBeDefined();
+	});
+
+	it('reflects the active tool from UI store', () => {
+		renderToolSelector();
+		const selectBtn = screen.getByLabelText('Select');
+		// ToggleGroup type="single" uses role="radio" with aria-checked
+		expect(selectBtn.getAttribute('aria-checked')).toBe('true');
+	});
+
+	it('updates UI store when a tool is clicked', async () => {
+		const user = userEvent.setup();
+		renderToolSelector();
+
+		await user.click(screen.getByLabelText('Hand'));
+		expect(useUIStore.getState().tool).toBe('pan');
+	});
+
+	it('syncs when store changes externally', () => {
+		renderToolSelector();
+		act(() => {
+			useUIStore.getState().setTool('draw-rect');
+		});
+		const rectBtn = screen.getByLabelText('Rectangle');
+		expect(rectBtn.getAttribute('aria-checked')).toBe('true');
+	});
+});

--- a/src/components/editor/tool-selector.tsx
+++ b/src/components/editor/tool-selector.tsx
@@ -3,6 +3,7 @@
 import { ArrowRight, Circle, Hand, Minus, MousePointer2, Square, Type } from 'lucide-react';
 import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { type ToolMode, useUIStore } from '@/lib/stores/ui-store';
 
 const tools = [
 	{ value: 'select', icon: MousePointer2, label: 'Select', shortcut: 'V' },
@@ -14,24 +15,54 @@ const tools = [
 	{ value: 'line', icon: Minus, label: 'Line', shortcut: 'L' },
 ] as const;
 
+const toolModeToValue: Record<ToolMode, string> = {
+	select: 'select',
+	pan: 'hand',
+	'draw-rect': 'rect',
+	'draw-ellipse': 'ellipse',
+	'draw-text': 'text',
+	'draw-arrow': 'arrow',
+	'draw-line': 'line',
+};
+
+const valueToToolMode: Record<string, ToolMode> = {
+	select: 'select',
+	hand: 'pan',
+	rect: 'draw-rect',
+	ellipse: 'draw-ellipse',
+	text: 'draw-text',
+	arrow: 'draw-arrow',
+	line: 'draw-line',
+};
+
 export function ToolSelector() {
+	const tool = useUIStore((s) => s.tool);
+	const setTool = useUIStore((s) => s.setTool);
+
 	return (
-		<ToggleGroup type="single" defaultValue="select" className="gap-0.5">
-			{tools.map((tool) => (
-				<Tooltip key={tool.value}>
+		<ToggleGroup
+			type="single"
+			value={toolModeToValue[tool]}
+			onValueChange={(val) => {
+				if (val) setTool(valueToToolMode[val]);
+			}}
+			className="gap-0.5"
+		>
+			{tools.map((t) => (
+				<Tooltip key={t.value}>
 					<TooltipTrigger asChild>
 						<ToggleGroupItem
-							value={tool.value}
-							aria-label={tool.label}
+							value={t.value}
+							aria-label={t.label}
 							className="h-8 w-8 data-[state=on]:bg-accent"
 						>
-							<tool.icon className="h-4 w-4" />
+							<t.icon className="h-4 w-4" />
 						</ToggleGroupItem>
 					</TooltipTrigger>
 					<TooltipContent>
 						<p>
-							{tool.label}
-							<span className="ml-2 text-muted-foreground">{tool.shortcut}</span>
+							{t.label}
+							<span className="ml-2 text-muted-foreground">{t.shortcut}</span>
 						</p>
 					</TooltipContent>
 				</Tooltip>

--- a/src/components/editor/toolbar.test.tsx
+++ b/src/components/editor/toolbar.test.tsx
@@ -1,0 +1,129 @@
+import { act, cleanup, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { useHistoryStore } from '@/lib/stores/history-store';
+import { useSceneStore } from '@/lib/stores/scene-store';
+import { useTimelineStore } from '@/lib/stores/timeline-store';
+import { useUIStore } from '@/lib/stores/ui-store';
+import { Toolbar } from './toolbar';
+
+function TestWrapper({ children }: { children: ReactNode }) {
+	return <TooltipProvider>{children}</TooltipProvider>;
+}
+
+function renderToolbar() {
+	return render(<Toolbar />, { wrapper: TestWrapper });
+}
+
+// Mock pixi.js imports for SceneManager dependency chain
+vi.mock('pixi.js', () => ({}));
+
+// ResizeObserver needed for shadcn components
+class MockResizeObserver {
+	observe = vi.fn();
+	unobserve = vi.fn();
+	disconnect = vi.fn();
+}
+vi.stubGlobal('ResizeObserver', MockResizeObserver);
+
+describe('Toolbar', () => {
+	beforeEach(() => {
+		useUIStore.getState().reset();
+		useTimelineStore.getState().reset();
+		useSceneStore.getState().reset();
+		useHistoryStore.getState().clearHistory();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	describe('rendering', () => {
+		it('renders the toolbar element', () => {
+			renderToolbar();
+			expect(screen.getByRole('toolbar')).toBeDefined();
+		});
+
+		it('renders the app logo', () => {
+			renderToolbar();
+			expect(screen.getByText('AlgoMotion')).toBeDefined();
+		});
+
+		it('renders File, Edit, View, Insert menus', () => {
+			renderToolbar();
+			expect(screen.getByText('File')).toBeDefined();
+			expect(screen.getByText('Edit')).toBeDefined();
+			expect(screen.getByText('View')).toBeDefined();
+			expect(screen.getByText('Insert')).toBeDefined();
+		});
+	});
+
+	describe('undo/redo buttons', () => {
+		it('renders undo and redo buttons', () => {
+			renderToolbar();
+			expect(screen.getByLabelText('Undo')).toBeDefined();
+			expect(screen.getByLabelText('Redo')).toBeDefined();
+		});
+
+		it('disables undo button when history stack is empty', () => {
+			renderToolbar();
+			const undoBtn = screen.getByLabelText('Undo');
+			expect(undoBtn).toHaveProperty('disabled', true);
+		});
+
+		it('disables redo button when no redo entries exist', () => {
+			renderToolbar();
+			const redoBtn = screen.getByLabelText('Redo');
+			expect(redoBtn).toHaveProperty('disabled', true);
+		});
+	});
+
+	describe('zoom controls', () => {
+		it('displays current zoom percentage', () => {
+			renderToolbar();
+			// Default zoom is 1 = 100%
+			expect(screen.getByText('100%')).toBeDefined();
+		});
+
+		it('updates zoom display when camera zoom changes', () => {
+			renderToolbar();
+			act(() => {
+				useSceneStore.getState().setCamera({ zoom: 2 });
+			});
+			expect(screen.getByText('200%')).toBeDefined();
+		});
+	});
+
+	describe('playback controls', () => {
+		it('renders play button', () => {
+			renderToolbar();
+			expect(screen.getByLabelText('Play')).toBeDefined();
+		});
+
+		it('renders pause button', () => {
+			renderToolbar();
+			expect(screen.getByLabelText('Pause')).toBeDefined();
+		});
+
+		it('renders stop button', () => {
+			renderToolbar();
+			expect(screen.getByLabelText('Stop')).toBeDefined();
+		});
+	});
+
+	describe('speed control', () => {
+		it('displays current speed', () => {
+			renderToolbar();
+			expect(screen.getByText('1x')).toBeDefined();
+		});
+
+		it('updates speed display when timeline speed changes', () => {
+			renderToolbar();
+			act(() => {
+				useTimelineStore.getState().setSpeed(2);
+			});
+			expect(screen.getByText('2x')).toBeDefined();
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- **Toolbar**: Wired undo/redo buttons to `HistoryStore` with `canUndo`/`canRedo` selectors for disabled state. Zoom display reactive to `SceneStore` camera zoom. Playback controls (play/pause/stop) wired to `TimelineStore`. Speed dropdown reactive and functional with `setSpeed`.
- **ToolSelector**: Changed from uncontrolled `defaultValue` to controlled `value` from `UIStore.tool` with bidirectional `ToolMode` mapping (`hand`↔`pan`, `rect`↔`draw-rect`, etc.). `onValueChange` calls `setTool` for full store sync.
- All action buttons now have `aria-label` for accessibility.
- Added `@testing-library/user-event` dev dependency for click simulation.

## Test plan

- [x] 13 toolbar tests: rendering (toolbar, logo, menus), undo/redo disabled state, reactive zoom percentage, playback buttons, reactive speed display
- [x] 4 tool-selector tests: renders all tools, reflects active tool from store, updates store on click, syncs when store changes externally
- [x] Quality gate: biome clean, tsc clean, all 504 tests pass

Closes #10

🤖 Generated with [Claude Code](https://claude.com/claude-code)