### PR TITLE
feat: implement centralized keyboard shortcuts system (#13)

### DIFF
--- a/src/components/editor/editor-layout.tsx
+++ b/src/components/editor/editor-layout.tsx
@@ -8,17 +8,19 @@ import { BottomPanel } from '@/components/panels/bottom-panel';
 import { LeftPanel } from '@/components/panels/left-panel';
 import { RightPanel } from '@/components/panels/right-panel';
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
+import { useGlobalShortcuts } from '@/hooks/use-global-shortcuts';
 import { useUIStore } from '@/lib/stores/ui-store';
 import { Toolbar } from './toolbar';
 
 export function EditorLayout() {
+	useGlobalShortcuts();
+
 	const leftRef = usePanelRef();
 	const rightRef = usePanelRef();
 	const bottomRef = usePanelRef();
 
 	const panelSizes = useUIStore((s) => s.panelSizes);
 	const panels = useUIStore((s) => s.panels);
-	const togglePanel = useUIStore((s) => s.togglePanel);
 	const setPanelSize = useUIStore((s) => s.setPanelSize);
 	const setPanelVisible = useUIStore((s) => s.setPanelVisible);
 
@@ -43,34 +45,6 @@ export function EditorLayout() {
 		if (panels.bottom && panel.isCollapsed()) panel.expand();
 		else if (!panels.bottom && !panel.isCollapsed()) panel.collapse();
 	}, [panels.bottom, bottomRef]);
-
-	// Keyboard shortcuts for panel toggle
-	useEffect(() => {
-		function handleKeyDown(e: KeyboardEvent) {
-			const isMod = e.metaKey || e.ctrlKey;
-			if (!isMod) return;
-
-			switch (e.key) {
-				case 'b':
-				case 'B':
-					e.preventDefault();
-					togglePanel('left');
-					break;
-				case 'i':
-				case 'I':
-					e.preventDefault();
-					togglePanel('right');
-					break;
-				case '`':
-					e.preventDefault();
-					togglePanel('bottom');
-					break;
-			}
-		}
-
-		document.addEventListener('keydown', handleKeyDown);
-		return () => document.removeEventListener('keydown', handleKeyDown);
-	}, [togglePanel]);
 
 	// Track resize and sync collapsed state back to store
 	const handleLeftResize = useCallback(

--- a/src/hooks/use-global-shortcuts.test.ts
+++ b/src/hooks/use-global-shortcuts.test.ts
@@ -1,0 +1,197 @@
+import { act, cleanup, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useHistoryStore } from '@/lib/stores/history-store';
+import { useSceneStore } from '@/lib/stores/scene-store';
+import { useTimelineStore } from '@/lib/stores/timeline-store';
+import { useUIStore } from '@/lib/stores/ui-store';
+import { useGlobalShortcuts } from './use-global-shortcuts';
+
+// Mock pixi.js for SceneManager dependency chain
+vi.mock('pixi.js', () => ({}));
+
+function fireKey(key: string, mods: Partial<KeyboardEventInit> = {}) {
+	act(() => {
+		document.dispatchEvent(
+			new KeyboardEvent('keydown', {
+				key,
+				bubbles: true,
+				...mods,
+			}),
+		);
+	});
+}
+
+describe('useGlobalShortcuts', () => {
+	beforeEach(() => {
+		useUIStore.getState().reset();
+		useTimelineStore.getState().reset();
+		useSceneStore.getState().reset();
+		useHistoryStore.getState().clearHistory();
+	});
+
+	afterEach(() => {
+		cleanup();
+	});
+
+	it('mounts and unmounts without errors', () => {
+		const { unmount } = renderHook(() => useGlobalShortcuts());
+		unmount();
+	});
+
+	describe('playback shortcuts', () => {
+		it('Space toggles play/pause', () => {
+			renderHook(() => useGlobalShortcuts());
+
+			expect(useTimelineStore.getState().playback.status).toBe('idle');
+			fireKey(' ');
+			expect(useTimelineStore.getState().playback.status).toBe('playing');
+			fireKey(' ');
+			expect(useTimelineStore.getState().playback.status).toBe('paused');
+		});
+	});
+
+	describe('undo/redo shortcuts', () => {
+		it('Ctrl+Z calls undo', () => {
+			const undoSpy = vi.spyOn(useHistoryStore.getState(), 'undo');
+			renderHook(() => useGlobalShortcuts());
+
+			fireKey('z', { ctrlKey: true });
+			expect(undoSpy).toHaveBeenCalled();
+			undoSpy.mockRestore();
+		});
+
+		it('Ctrl+Shift+Z calls redo', () => {
+			const redoSpy = vi.spyOn(useHistoryStore.getState(), 'redo');
+			renderHook(() => useGlobalShortcuts());
+
+			fireKey('z', { ctrlKey: true, shiftKey: true });
+			expect(redoSpy).toHaveBeenCalled();
+			redoSpy.mockRestore();
+		});
+	});
+
+	describe('zoom shortcuts', () => {
+		it('Ctrl+= zooms in', () => {
+			renderHook(() => useGlobalShortcuts());
+			const initialZoom = useSceneStore.getState().camera.zoom;
+
+			fireKey('=', { ctrlKey: true });
+			expect(useSceneStore.getState().camera.zoom).toBeGreaterThan(initialZoom);
+		});
+
+		it('Ctrl+- zooms out', () => {
+			renderHook(() => useGlobalShortcuts());
+			const initialZoom = useSceneStore.getState().camera.zoom;
+
+			fireKey('-', { ctrlKey: true });
+			expect(useSceneStore.getState().camera.zoom).toBeLessThan(initialZoom);
+		});
+
+		it('Ctrl+0 resets zoom to 1', () => {
+			renderHook(() => useGlobalShortcuts());
+			useSceneStore.getState().setCamera({ zoom: 2.5 });
+
+			fireKey('0', { ctrlKey: true });
+			expect(useSceneStore.getState().camera.zoom).toBe(1);
+		});
+	});
+
+	describe('view shortcuts', () => {
+		it('Ctrl+; toggles grid visibility', () => {
+			renderHook(() => useGlobalShortcuts());
+			expect(useUIStore.getState().gridVisible).toBe(true);
+
+			fireKey(';', { ctrlKey: true });
+			expect(useUIStore.getState().gridVisible).toBe(false);
+
+			fireKey(';', { ctrlKey: true });
+			expect(useUIStore.getState().gridVisible).toBe(true);
+		});
+	});
+
+	describe('save shortcut', () => {
+		it('Ctrl+S prevents default browser save dialog', () => {
+			renderHook(() => useGlobalShortcuts());
+
+			const event = new KeyboardEvent('keydown', {
+				key: 's',
+				ctrlKey: true,
+				bubbles: true,
+				cancelable: true,
+			});
+			const preventSpy = vi.spyOn(event, 'preventDefault');
+
+			act(() => {
+				document.dispatchEvent(event);
+			});
+
+			expect(preventSpy).toHaveBeenCalled();
+		});
+	});
+
+	describe('context awareness', () => {
+		it('does NOT fire shortcuts when an input element is focused', () => {
+			renderHook(() => useGlobalShortcuts());
+
+			const input = document.createElement('input');
+			document.body.appendChild(input);
+			input.focus();
+
+			const initialStatus = useTimelineStore.getState().playback.status;
+			fireKey(' ');
+			expect(useTimelineStore.getState().playback.status).toBe(initialStatus);
+
+			document.body.removeChild(input);
+		});
+
+		it('does NOT fire shortcuts when a textarea is focused', () => {
+			renderHook(() => useGlobalShortcuts());
+
+			const textarea = document.createElement('textarea');
+			document.body.appendChild(textarea);
+			textarea.focus();
+
+			const initialStatus = useTimelineStore.getState().playback.status;
+			fireKey(' ');
+			expect(useTimelineStore.getState().playback.status).toBe(initialStatus);
+
+			document.body.removeChild(textarea);
+		});
+
+		it('does NOT fire shortcuts when contenteditable element is focused', () => {
+			renderHook(() => useGlobalShortcuts());
+
+			const div = document.createElement('div');
+			div.setAttribute('contenteditable', 'true');
+			document.body.appendChild(div);
+			div.focus();
+
+			const initialStatus = useTimelineStore.getState().playback.status;
+			fireKey(' ');
+			expect(useTimelineStore.getState().playback.status).toBe(initialStatus);
+
+			document.body.removeChild(div);
+		});
+
+		it('DOES fire shortcuts when no text input is focused', () => {
+			renderHook(() => useGlobalShortcuts());
+
+			// Focus on body (no text input)
+			document.body.focus();
+
+			fireKey(' ');
+			expect(useTimelineStore.getState().playback.status).toBe('playing');
+		});
+	});
+
+	describe('cleanup', () => {
+		it('removes listener on unmount', () => {
+			const { unmount } = renderHook(() => useGlobalShortcuts());
+			unmount();
+
+			const initialStatus = useTimelineStore.getState().playback.status;
+			fireKey(' ');
+			expect(useTimelineStore.getState().playback.status).toBe(initialStatus);
+		});
+	});
+});

--- a/src/hooks/use-global-shortcuts.ts
+++ b/src/hooks/use-global-shortcuts.ts
@@ -1,0 +1,96 @@
+import { useEffect } from 'react';
+import { matchesKeyEvent, shortcutRegistry } from '@/lib/shortcuts/shortcut-registry';
+import { useHistoryStore } from '@/lib/stores/history-store';
+import { useSceneStore } from '@/lib/stores/scene-store';
+import { useTimelineStore } from '@/lib/stores/timeline-store';
+import { useUIStore } from '@/lib/stores/ui-store';
+
+const ZOOM_STEP = 0.25;
+const ZOOM_MIN = 0.1;
+const ZOOM_MAX = 5;
+
+/**
+ * Returns true if the active element is a text input where
+ * keyboard shortcuts should be suppressed.
+ */
+function isTextInputFocused(): boolean {
+	const el = document.activeElement;
+	if (!el) return false;
+
+	const tag = el.tagName;
+	if (tag === 'INPUT' || tag === 'TEXTAREA') return true;
+	if ((el as HTMLElement).isContentEditable || el.getAttribute('contenteditable') === 'true')
+		return true;
+
+	return false;
+}
+
+/**
+ * Shortcut action handlers keyed by shortcut ID.
+ * Returns a record mapping shortcut IDs to their action callbacks.
+ */
+function getActions(): Record<string, () => void> {
+	return {
+		'play-pause': () => {
+			const { playback, play, pause } = useTimelineStore.getState();
+			if (playback.status === 'playing') {
+				pause();
+			} else {
+				play();
+			}
+		},
+		undo: () => useHistoryStore.getState().undo(),
+		redo: () => useHistoryStore.getState().redo(),
+		save: () => {
+			// Save is handled elsewhere — this just prevents browser save dialog
+		},
+		'zoom-in': () => {
+			const { camera, setCamera } = useSceneStore.getState();
+			setCamera({ zoom: Math.min(camera.zoom + ZOOM_STEP, ZOOM_MAX) });
+		},
+		'zoom-out': () => {
+			const { camera, setCamera } = useSceneStore.getState();
+			setCamera({ zoom: Math.max(camera.zoom - ZOOM_STEP, ZOOM_MIN) });
+		},
+		'fit-to-screen': () => {
+			useSceneStore.getState().setCamera({ zoom: 1, x: 0, y: 0 });
+		},
+		'toggle-grid': () => useUIStore.getState().toggleGrid(),
+		'toggle-left-panel': () => useUIStore.getState().togglePanel('left'),
+		'toggle-right-panel': () => useUIStore.getState().togglePanel('right'),
+		'toggle-bottom-panel': () => useUIStore.getState().togglePanel('bottom'),
+	};
+}
+
+/**
+ * Binds global keyboard shortcuts to the document.
+ *
+ * Context-aware: shortcuts are suppressed when a text input,
+ * textarea, or contenteditable element is focused.
+ *
+ * This replaces the inline keyboard handlers in EditorLayout
+ * with a centralized system backed by the shortcut registry.
+ */
+export function useGlobalShortcuts(): void {
+	useEffect(() => {
+		function handleKeyDown(e: KeyboardEvent) {
+			if (isTextInputFocused()) return;
+
+			const actions = getActions();
+
+			for (const shortcut of shortcutRegistry) {
+				if (matchesKeyEvent(shortcut.keys, e)) {
+					const action = actions[shortcut.id];
+					if (action) {
+						e.preventDefault();
+						action();
+					}
+					return;
+				}
+			}
+		}
+
+		document.addEventListener('keydown', handleKeyDown);
+		return () => document.removeEventListener('keydown', handleKeyDown);
+	}, []);
+}

--- a/src/lib/shortcuts/shortcut-registry.test.ts
+++ b/src/lib/shortcuts/shortcut-registry.test.ts
@@ -1,0 +1,185 @@
+import { describe, expect, it } from 'vitest';
+import {
+	formatShortcut,
+	getShortcutsByCategory,
+	matchesKeyEvent,
+	type ShortcutDefinition,
+	shortcutRegistry,
+} from './shortcut-registry';
+
+describe('shortcutRegistry', () => {
+	it('exports a non-empty array of shortcut definitions', () => {
+		expect(shortcutRegistry.length).toBeGreaterThan(0);
+	});
+
+	it('every entry has required fields', () => {
+		for (const entry of shortcutRegistry) {
+			expect(entry.id).toBeTruthy();
+			expect(entry.label).toBeTruthy();
+			expect(entry.category).toBeTruthy();
+			expect(entry.keys).toBeDefined();
+			expect(entry.keys.key).toBeTruthy();
+		}
+	});
+
+	it('has no duplicate IDs', () => {
+		const ids = shortcutRegistry.map((s) => s.id);
+		expect(new Set(ids).size).toBe(ids.length);
+	});
+
+	describe('required shortcuts exist', () => {
+		const requiredIds = [
+			'play-pause',
+			'undo',
+			'redo',
+			'zoom-in',
+			'zoom-out',
+			'fit-to-screen',
+			'toggle-grid',
+			'save',
+			'toggle-bottom-panel',
+			'toggle-left-panel',
+			'toggle-right-panel',
+		];
+
+		for (const id of requiredIds) {
+			it(`includes "${id}" shortcut`, () => {
+				expect(shortcutRegistry.find((s) => s.id === id)).toBeDefined();
+			});
+		}
+	});
+});
+
+describe('matchesKeyEvent', () => {
+	function makeKeyEvent(overrides: Partial<KeyboardEvent> = {}): KeyboardEvent {
+		return {
+			key: '',
+			ctrlKey: false,
+			metaKey: false,
+			shiftKey: false,
+			altKey: false,
+			...overrides,
+		} as KeyboardEvent;
+	}
+
+	it('matches simple key without modifiers', () => {
+		const def: ShortcutDefinition = {
+			id: 'test',
+			label: 'Test',
+			category: 'test',
+			keys: { key: ' ' },
+		};
+		expect(matchesKeyEvent(def.keys, makeKeyEvent({ key: ' ' }))).toBe(true);
+	});
+
+	it('matches Ctrl+key (ctrlKey)', () => {
+		const def: ShortcutDefinition = {
+			id: 'test',
+			label: 'Test',
+			category: 'test',
+			keys: { key: 'z', mod: true },
+		};
+		expect(matchesKeyEvent(def.keys, makeKeyEvent({ key: 'z', ctrlKey: true }))).toBe(true);
+	});
+
+	it('matches Cmd+key (metaKey) when mod is true', () => {
+		const def: ShortcutDefinition = {
+			id: 'test',
+			label: 'Test',
+			category: 'test',
+			keys: { key: 'z', mod: true },
+		};
+		expect(matchesKeyEvent(def.keys, makeKeyEvent({ key: 'z', metaKey: true }))).toBe(true);
+	});
+
+	it('does not match when mod required but no modifier pressed', () => {
+		const def: ShortcutDefinition = {
+			id: 'test',
+			label: 'Test',
+			category: 'test',
+			keys: { key: 'z', mod: true },
+		};
+		expect(matchesKeyEvent(def.keys, makeKeyEvent({ key: 'z' }))).toBe(false);
+	});
+
+	it('matches Ctrl+Shift+key', () => {
+		const def: ShortcutDefinition = {
+			id: 'test',
+			label: 'Test',
+			category: 'test',
+			keys: { key: 'z', mod: true, shift: true },
+		};
+		expect(
+			matchesKeyEvent(def.keys, makeKeyEvent({ key: 'z', ctrlKey: true, shiftKey: true })),
+		).toBe(true);
+	});
+
+	it('does not match wrong key', () => {
+		const def: ShortcutDefinition = {
+			id: 'test',
+			label: 'Test',
+			category: 'test',
+			keys: { key: 'z', mod: true },
+		};
+		expect(matchesKeyEvent(def.keys, makeKeyEvent({ key: 'a', ctrlKey: true }))).toBe(false);
+	});
+
+	it('does not match when shift required but not pressed', () => {
+		const def: ShortcutDefinition = {
+			id: 'test',
+			label: 'Test',
+			category: 'test',
+			keys: { key: 'z', mod: true, shift: true },
+		};
+		expect(matchesKeyEvent(def.keys, makeKeyEvent({ key: 'z', ctrlKey: true }))).toBe(false);
+	});
+
+	it('is case-insensitive for letter keys', () => {
+		const def: ShortcutDefinition = {
+			id: 'test',
+			label: 'Test',
+			category: 'test',
+			keys: { key: 'z', mod: true },
+		};
+		expect(matchesKeyEvent(def.keys, makeKeyEvent({ key: 'Z', ctrlKey: true }))).toBe(true);
+	});
+});
+
+describe('formatShortcut', () => {
+	it('formats a mod+key shortcut', () => {
+		const formatted = formatShortcut({ key: 'z', mod: true });
+		// Should include either Ctrl or ⌘ depending on platform
+		expect(formatted).toMatch(/[Ctrl⌘]/);
+		expect(formatted.toLowerCase()).toContain('z');
+	});
+
+	it('formats mod+shift+key shortcut', () => {
+		const formatted = formatShortcut({ key: 'z', mod: true, shift: true });
+		expect(formatted).toMatch(/[Shift⇧]/i);
+	});
+
+	it('formats Space key', () => {
+		const formatted = formatShortcut({ key: ' ' });
+		expect(formatted).toBe('Space');
+	});
+});
+
+describe('getShortcutsByCategory', () => {
+	it('groups shortcuts by category', () => {
+		const grouped = getShortcutsByCategory();
+		expect(Object.keys(grouped).length).toBeGreaterThan(0);
+
+		// Each group should be non-empty
+		for (const [, shortcuts] of Object.entries(grouped)) {
+			expect(shortcuts.length).toBeGreaterThan(0);
+		}
+	});
+
+	it('every shortcut appears in exactly one category', () => {
+		const grouped = getShortcutsByCategory();
+		const allIds = Object.values(grouped)
+			.flat()
+			.map((s) => s.id);
+		expect(allIds.length).toBe(shortcutRegistry.length);
+	});
+});

--- a/src/lib/shortcuts/shortcut-registry.ts
+++ b/src/lib/shortcuts/shortcut-registry.ts
@@ -1,0 +1,141 @@
+/**
+ * Central keyboard shortcut registry.
+ *
+ * All shortcuts are defined here with their key combos, labels, and categories.
+ * The registry is consumed by:
+ *   - useGlobalShortcuts hook (binds to document keydown)
+ *   - Command palette (lists all shortcuts with search)
+ *   - Toolbar/menu shortcut labels
+ *
+ * `mod` means Ctrl on Windows/Linux, Cmd on Mac.
+ */
+
+export interface ShortcutKeys {
+	key: string;
+	mod?: boolean;
+	shift?: boolean;
+	alt?: boolean;
+}
+
+export interface ShortcutDefinition {
+	id: string;
+	label: string;
+	category: string;
+	keys: ShortcutKeys;
+	/** Override for display — auto-formatted from keys if not provided */
+	displayShortcut?: string;
+}
+
+const isMac = typeof navigator !== 'undefined' && /Mac|iPod|iPhone|iPad/.test(navigator.userAgent);
+
+/**
+ * Check whether a KeyboardEvent matches a ShortcutKeys definition.
+ * `mod` matches either Ctrl or Meta (Cmd on Mac).
+ */
+export function matchesKeyEvent(keys: ShortcutKeys, e: KeyboardEvent): boolean {
+	const eventKey = e.key.toLowerCase();
+	const defKey = keys.key.toLowerCase();
+
+	if (eventKey !== defKey) return false;
+
+	const wantsMod = keys.mod ?? false;
+	const hasMod = e.ctrlKey || e.metaKey;
+	if (wantsMod !== hasMod) return false;
+
+	const wantsShift = keys.shift ?? false;
+	if (wantsShift !== e.shiftKey) return false;
+
+	const wantsAlt = keys.alt ?? false;
+	if (wantsAlt !== e.altKey) return false;
+
+	return true;
+}
+
+/**
+ * Format a ShortcutKeys definition into a human-readable string.
+ */
+export function formatShortcut(keys: ShortcutKeys): string {
+	const parts: string[] = [];
+
+	if (keys.mod) parts.push(isMac ? '⌘' : 'Ctrl');
+	if (keys.shift) parts.push(isMac ? '⇧' : 'Shift');
+	if (keys.alt) parts.push(isMac ? '⌥' : 'Alt');
+
+	// Friendly names for special keys
+	const keyMap: Record<string, string> = {
+		' ': 'Space',
+		ArrowUp: '↑',
+		ArrowDown: '↓',
+		ArrowLeft: '←',
+		ArrowRight: '→',
+		Delete: 'Del',
+		Backspace: '⌫',
+		Escape: 'Esc',
+		'`': '`',
+		';': ';',
+		'=': '=',
+		'-': '-',
+		'0': '0',
+	};
+
+	const displayKey = keyMap[keys.key] ?? keys.key.toUpperCase();
+	parts.push(displayKey);
+
+	return parts.join(isMac ? '' : '+');
+}
+
+/**
+ * Group shortcuts by category for command palette display.
+ */
+export function getShortcutsByCategory(): Record<string, ShortcutDefinition[]> {
+	const result: Record<string, ShortcutDefinition[]> = {};
+	for (const shortcut of shortcutRegistry) {
+		const list = result[shortcut.category] ?? [];
+		list.push(shortcut);
+		result[shortcut.category] = list;
+	}
+	return result;
+}
+
+/**
+ * The central shortcut registry.
+ *
+ * Actions are NOT defined here — they're wired up in `useGlobalShortcuts`
+ * which maps shortcut IDs to store actions. This keeps the registry
+ * as pure data that can be imported without pulling in store dependencies.
+ */
+export const shortcutRegistry: ShortcutDefinition[] = [
+	// Playback
+	{ id: 'play-pause', label: 'Play / Pause', category: 'Playback', keys: { key: ' ' } },
+
+	// Edit
+	{ id: 'undo', label: 'Undo', category: 'Edit', keys: { key: 'z', mod: true } },
+	{ id: 'redo', label: 'Redo', category: 'Edit', keys: { key: 'z', mod: true, shift: true } },
+	{ id: 'save', label: 'Save', category: 'Edit', keys: { key: 's', mod: true } },
+
+	// Zoom
+	{ id: 'zoom-in', label: 'Zoom In', category: 'View', keys: { key: '=', mod: true } },
+	{ id: 'zoom-out', label: 'Zoom Out', category: 'View', keys: { key: '-', mod: true } },
+	{ id: 'fit-to-screen', label: 'Fit to Screen', category: 'View', keys: { key: '0', mod: true } },
+
+	// View
+	{ id: 'toggle-grid', label: 'Toggle Grid', category: 'View', keys: { key: ';', mod: true } },
+	{
+		id: 'toggle-left-panel',
+		label: 'Toggle Left Panel',
+		category: 'View',
+		keys: { key: 'b', mod: true },
+	},
+	{
+		id: 'toggle-right-panel',
+		label: 'Toggle Right Panel',
+		category: 'View',
+		keys: { key: 'i', mod: true },
+	},
+	{
+		id: 'toggle-bottom-panel',
+		label: 'Toggle Bottom Panel',
+		category: 'View',
+		keys: { key: '`', mod: true },
+	},
+];


### PR DESCRIPTION
## Summary

- **ShortcutRegistry** (`src/lib/shortcuts/shortcut-registry.ts`): Central array of `ShortcutDefinition` objects with IDs, labels, categories, and key combos (`mod`/`shift`/`alt`). Pure data module with `matchesKeyEvent()`, `formatShortcut()`, and `getShortcutsByCategory()` utilities for command palette integration.
- **useGlobalShortcuts hook** (`src/hooks/use-global-shortcuts.ts`): Binds a single document-level `keydown` listener that matches events against the registry and dispatches to store actions. Context-aware — suppresses shortcuts when `<input>`, `<textarea>`, or `contenteditable` elements are focused.
- **EditorLayout refactor**: Replaced inline keyboard handler (Ctrl+B/I/`) with `useGlobalShortcuts()` call. 29 lines of inline handler code removed, replaced by centralized system.

### Shortcuts implemented:
| Action | Shortcut |
|---|---|
| Play/Pause | Space |
| Undo | Ctrl+Z |
| Redo | Ctrl+Shift+Z |
| Save | Ctrl+S |
| Zoom In | Ctrl+= |
| Zoom Out | Ctrl+- |
| Fit to Screen | Ctrl+0 |
| Toggle Grid | Ctrl+; |
| Toggle Left Panel | Ctrl+B |
| Toggle Right Panel | Ctrl+I |
| Toggle Bottom Panel | Ctrl+` |

## Test plan

- [x] 27 registry tests: required shortcuts exist, no duplicate IDs, matchesKeyEvent (case-insensitive, mod/shift combos), formatShortcut, getShortcutsByCategory
- [x] 14 hook tests: playback toggle, undo/redo, zoom in/out/fit, grid toggle, save preventDefault, context awareness (input/textarea/contenteditable suppression), cleanup on unmount
- [x] 17 existing editor-layout tests still pass (keyboard shortcuts now routed through useGlobalShortcuts)
- [x] Quality gate: biome clean, tsc clean, all 545 tests pass

Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)