### PR TITLE
feat: implement IndexedDB persistence with Dexie.js (#14)

### DIFF
--- a/src/components/editor/editor-layout.tsx
+++ b/src/components/editor/editor-layout.tsx
@@ -8,12 +8,14 @@ import { BottomPanel } from '@/components/panels/bottom-panel';
 import { LeftPanel } from '@/components/panels/left-panel';
 import { RightPanel } from '@/components/panels/right-panel';
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
+import { useAutoSave } from '@/hooks/use-auto-save';
 import { useGlobalShortcuts } from '@/hooks/use-global-shortcuts';
 import { useUIStore } from '@/lib/stores/ui-store';
 import { Toolbar } from './toolbar';
 
 export function EditorLayout() {
 	useGlobalShortcuts();
+	useAutoSave();
 
 	const leftRef = usePanelRef();
 	const rightRef = usePanelRef();

--- a/src/hooks/use-auto-save.test.ts
+++ b/src/hooks/use-auto-save.test.ts
@@ -1,0 +1,179 @@
+import { act, renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import * as persistence from '@/lib/persistence/project-persistence';
+import { useProjectStore } from '@/lib/stores/project-store';
+import { useAutoSave } from './use-auto-save';
+
+vi.mock('@/lib/persistence/project-persistence', () => ({
+	saveProjectToIndex: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mockSaveProjectToIndex = vi.mocked(persistence.saveProjectToIndex);
+
+function makeProject() {
+	return {
+		id: 'proj-auto',
+		name: 'Auto Save Project',
+		description: '',
+		thumbnail: '',
+		createdAt: '2026-01-01T00:00:00.000Z',
+		updatedAt: '2026-01-01T00:00:00.000Z',
+		userId: 'user-1',
+		isPublic: false,
+		tags: [],
+		settings: {
+			canvasWidth: 1920,
+			canvasHeight: 1080,
+			backgroundColor: '#1e1e2e',
+			backgroundStyle: 'grid' as const,
+			gridSize: 20,
+			snapToGrid: true,
+			fps: 60,
+			defaultEasing: 'power2.out',
+			theme: 'dark' as const,
+		},
+		sceneIds: [],
+	};
+}
+
+describe('useAutoSave', () => {
+	beforeEach(() => {
+		vi.useFakeTimers();
+		mockSaveProjectToIndex.mockClear();
+		useProjectStore.getState().reset();
+	});
+
+	afterEach(() => {
+		vi.useRealTimers();
+	});
+
+	it('does not save when project is not dirty', async () => {
+		const project = makeProject();
+		act(() => {
+			useProjectStore.getState().setProject(project);
+		});
+
+		renderHook(() => useAutoSave());
+
+		await act(async () => {
+			vi.advanceTimersByTime(6000);
+		});
+
+		expect(mockSaveProjectToIndex).not.toHaveBeenCalled();
+	});
+
+	it('saves when project becomes dirty after debounce interval', async () => {
+		const project = makeProject();
+		act(() => {
+			useProjectStore.getState().setProject(project);
+		});
+
+		renderHook(() => useAutoSave());
+
+		act(() => {
+			useProjectStore.getState().markDirty();
+		});
+
+		await act(async () => {
+			vi.advanceTimersByTime(6000);
+		});
+
+		expect(mockSaveProjectToIndex).toHaveBeenCalledOnce();
+	});
+
+	it('does not save when there is no project', async () => {
+		renderHook(() => useAutoSave());
+
+		act(() => {
+			useProjectStore.getState().markDirty();
+		});
+
+		await act(async () => {
+			vi.advanceTimersByTime(6000);
+		});
+
+		expect(mockSaveProjectToIndex).not.toHaveBeenCalled();
+	});
+
+	it('marks project as saved after successful auto-save', async () => {
+		const project = makeProject();
+		act(() => {
+			useProjectStore.getState().setProject(project);
+			useProjectStore.getState().markDirty();
+		});
+
+		renderHook(() => useAutoSave());
+
+		await act(async () => {
+			vi.advanceTimersByTime(6000);
+		});
+
+		expect(useProjectStore.getState().isDirty).toBe(false);
+	});
+
+	it('debounces rapid changes', async () => {
+		const project = makeProject();
+		act(() => {
+			useProjectStore.getState().setProject(project);
+		});
+
+		renderHook(() => useAutoSave());
+
+		// Mark dirty multiple times rapidly
+		act(() => {
+			useProjectStore.getState().markDirty();
+		});
+		await act(async () => {
+			vi.advanceTimersByTime(2000);
+		});
+		act(() => {
+			useProjectStore.getState().markDirty();
+		});
+		await act(async () => {
+			vi.advanceTimersByTime(2000);
+		});
+		act(() => {
+			useProjectStore.getState().markDirty();
+		});
+
+		// Not called yet — debounce timer keeps resetting
+		expect(mockSaveProjectToIndex).not.toHaveBeenCalled();
+
+		// After full debounce interval from last change
+		await act(async () => {
+			vi.advanceTimersByTime(6000);
+		});
+
+		expect(mockSaveProjectToIndex).toHaveBeenCalledOnce();
+	});
+});
+
+describe('saveProject (manual)', () => {
+	beforeEach(() => {
+		mockSaveProjectToIndex.mockClear();
+		useProjectStore.getState().reset();
+	});
+
+	it('exports a saveProject function that saves immediately', async () => {
+		const { saveProject } = await import('./use-auto-save');
+
+		const project = makeProject();
+		act(() => {
+			useProjectStore.getState().setProject(project);
+			useProjectStore.getState().markDirty();
+		});
+
+		await saveProject();
+
+		expect(mockSaveProjectToIndex).toHaveBeenCalledOnce();
+		expect(useProjectStore.getState().isDirty).toBe(false);
+	});
+
+	it('does nothing when there is no project', async () => {
+		const { saveProject } = await import('./use-auto-save');
+
+		await saveProject();
+
+		expect(mockSaveProjectToIndex).not.toHaveBeenCalled();
+	});
+});

--- a/src/hooks/use-auto-save.ts
+++ b/src/hooks/use-auto-save.ts
@@ -1,0 +1,61 @@
+import { useEffect, useRef } from 'react';
+import { saveProjectToIndex } from '@/lib/persistence/project-persistence';
+import { useProjectStore } from '@/lib/stores/project-store';
+
+const AUTO_SAVE_INTERVAL_MS = 5000;
+
+/**
+ * Manually save the current project to IndexedDB.
+ * Used by the Ctrl+S shortcut handler.
+ */
+export async function saveProject(): Promise<void> {
+	const { project, isDirty } = useProjectStore.getState();
+	if (!project || !isDirty) return;
+
+	await saveProjectToIndex(project);
+	useProjectStore.getState().markSaved();
+}
+
+/**
+ * Auto-save hook that persists the project to IndexedDB
+ * when dirty, debounced to avoid excessive writes.
+ *
+ * Subscribes to the project store outside of React render
+ * and uses a timer-based debounce.
+ */
+export function useAutoSave(): void {
+	const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+	useEffect(() => {
+		function scheduleSave() {
+			if (timerRef.current) {
+				clearTimeout(timerRef.current);
+			}
+			timerRef.current = setTimeout(async () => {
+				const { project, isDirty } = useProjectStore.getState();
+				if (!project || !isDirty) return;
+
+				await saveProjectToIndex(project);
+				useProjectStore.getState().markSaved();
+			}, AUTO_SAVE_INTERVAL_MS);
+		}
+
+		// If already dirty on mount, schedule a save
+		const { project, isDirty } = useProjectStore.getState();
+		if (project && isDirty) {
+			scheduleSave();
+		}
+
+		const unsubscribe = useProjectStore.subscribe((state) => {
+			if (!state.isDirty || !state.project) return;
+			scheduleSave();
+		});
+
+		return () => {
+			unsubscribe();
+			if (timerRef.current) {
+				clearTimeout(timerRef.current);
+			}
+		};
+	}, []);
+}

--- a/src/hooks/use-global-shortcuts.ts
+++ b/src/hooks/use-global-shortcuts.ts
@@ -1,4 +1,5 @@
 import { useEffect } from 'react';
+import { saveProject } from '@/hooks/use-auto-save';
 import { matchesKeyEvent, shortcutRegistry } from '@/lib/shortcuts/shortcut-registry';
 import { useHistoryStore } from '@/lib/stores/history-store';
 import { useSceneStore } from '@/lib/stores/scene-store';
@@ -42,7 +43,7 @@ function getActions(): Record<string, () => void> {
 		undo: () => useHistoryStore.getState().undo(),
 		redo: () => useHistoryStore.getState().redo(),
 		save: () => {
-			// Save is handled elsewhere — this just prevents browser save dialog
+			saveProject();
 		},
 		'zoom-in': () => {
 			const { camera, setCamera } = useSceneStore.getState();

--- a/src/lib/persistence/project-persistence.test.ts
+++ b/src/lib/persistence/project-persistence.test.ts
@@ -1,0 +1,120 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import type { Project } from '@/types';
+import {
+	deleteProject,
+	getProjectIndex,
+	listProjects,
+	saveProjectToIndex,
+} from './project-persistence';
+
+function makeProject(overrides: Partial<Project> = {}): Project {
+	return {
+		id: `proj-${Math.random().toString(36).slice(2, 8)}`,
+		name: 'Test Project',
+		description: 'A test project',
+		thumbnail: '',
+		createdAt: '2026-01-01T00:00:00.000Z',
+		updatedAt: '2026-01-01T00:00:00.000Z',
+		userId: 'user-1',
+		isPublic: false,
+		tags: ['test'],
+		settings: {
+			canvasWidth: 1920,
+			canvasHeight: 1080,
+			backgroundColor: '#1e1e2e',
+			backgroundStyle: 'grid',
+			gridSize: 20,
+			snapToGrid: true,
+			fps: 60,
+			defaultEasing: 'power2.out',
+			theme: 'dark',
+		},
+		sceneIds: [],
+		...overrides,
+	};
+}
+
+describe('project-persistence', () => {
+	beforeEach(async () => {
+		// Clear all projects before each test
+		const projects = await listProjects();
+		for (const p of projects) {
+			await deleteProject(p.id);
+		}
+	});
+
+	afterEach(async () => {
+		const projects = await listProjects();
+		for (const p of projects) {
+			await deleteProject(p.id);
+		}
+	});
+
+	describe('saveProjectToIndex', () => {
+		it('saves project metadata to the index', async () => {
+			const project = makeProject({ id: 'proj-save-1', name: 'Saved Project' });
+			await saveProjectToIndex(project);
+
+			const entry = await getProjectIndex('proj-save-1');
+			expect(entry).toBeDefined();
+			expect(entry?.name).toBe('Saved Project');
+		});
+
+		it('updates existing entry on re-save', async () => {
+			const project = makeProject({ id: 'proj-update', name: 'Original' });
+			await saveProjectToIndex(project);
+
+			const updated = { ...project, name: 'Updated', updatedAt: '2026-02-01T00:00:00.000Z' };
+			await saveProjectToIndex(updated);
+
+			const entry = await getProjectIndex('proj-update');
+			expect(entry?.name).toBe('Updated');
+		});
+	});
+
+	describe('listProjects', () => {
+		it('returns empty array when no projects saved', async () => {
+			const projects = await listProjects();
+			expect(projects).toEqual([]);
+		});
+
+		it('lists all saved projects', async () => {
+			await saveProjectToIndex(makeProject({ id: 'proj-a', name: 'Project A' }));
+			await saveProjectToIndex(makeProject({ id: 'proj-b', name: 'Project B' }));
+
+			const projects = await listProjects();
+			expect(projects).toHaveLength(2);
+			const names = projects.map((p) => p.name);
+			expect(names).toContain('Project A');
+			expect(names).toContain('Project B');
+		});
+	});
+
+	describe('getProjectIndex', () => {
+		it('returns undefined for non-existent project', async () => {
+			const entry = await getProjectIndex('nonexistent');
+			expect(entry).toBeUndefined();
+		});
+
+		it('returns the project index entry', async () => {
+			await saveProjectToIndex(makeProject({ id: 'proj-get', name: 'Get Me' }));
+			const entry = await getProjectIndex('proj-get');
+			expect(entry?.id).toBe('proj-get');
+			expect(entry?.name).toBe('Get Me');
+		});
+	});
+
+	describe('deleteProject', () => {
+		it('removes a project from the index', async () => {
+			await saveProjectToIndex(makeProject({ id: 'proj-del' }));
+			await deleteProject('proj-del');
+
+			const entry = await getProjectIndex('proj-del');
+			expect(entry).toBeUndefined();
+		});
+
+		it('does not throw when deleting non-existent project', async () => {
+			await expect(deleteProject('nonexistent')).resolves.not.toThrow();
+		});
+	});
+});

--- a/src/lib/persistence/project-persistence.ts
+++ b/src/lib/persistence/project-persistence.ts
@@ -1,0 +1,34 @@
+import { getDB } from '@/lib/stores/dexie-storage';
+import type { Project } from '@/types';
+
+/**
+ * Save project metadata to the IndexedDB project index.
+ * Uses `put` so it upserts — inserts or updates if the ID already exists.
+ */
+export async function saveProjectToIndex(project: Project): Promise<void> {
+	await getDB().projects.put(project);
+}
+
+/**
+ * List all projects from the IndexedDB index.
+ * Returns the full project metadata for dashboard display.
+ */
+export async function listProjects(): Promise<Project[]> {
+	return getDB().projects.toArray();
+}
+
+/**
+ * Get a single project index entry by ID.
+ * Returns undefined if the project is not found.
+ */
+export async function getProjectIndex(id: string): Promise<Project | undefined> {
+	return getDB().projects.get(id);
+}
+
+/**
+ * Delete a project from the IndexedDB index.
+ * No-op if the project doesn't exist.
+ */
+export async function deleteProject(id: string): Promise<void> {
+	await getDB().projects.delete(id);
+}

--- a/src/lib/stores/dexie-storage.ts
+++ b/src/lib/stores/dexie-storage.ts
@@ -1,22 +1,29 @@
 import Dexie from 'dexie';
 import type { StateStorage } from 'zustand/middleware';
+import type { Project } from '@/types';
 
 /**
- * IndexedDB database for Zustand store persistence.
+ * IndexedDB database for Zustand store persistence and project index.
  * Uses Dexie.js 4.3+ for the underlying IndexedDB access.
+ *
+ * Version history:
+ *   v1 — `stores` table (Zustand persist middleware key-value storage)
+ *   v2 — `projects` table (project index for dashboard listing)
  */
 class AlgoMotionDB extends Dexie {
 	stores!: Dexie.Table<{ key: string; value: string }, string>;
+	projects!: Dexie.Table<Project, string>;
 
 	constructor() {
 		super('AlgoMotionDB');
 		this.version(1).stores({ stores: 'key' });
+		this.version(2).stores({ projects: 'id, name, updatedAt, userId' });
 	}
 }
 
 let db: AlgoMotionDB | null = null;
 
-function getDB(): AlgoMotionDB {
+export function getDB(): AlgoMotionDB {
 	if (!db) {
 		db = new AlgoMotionDB();
 	}


### PR DESCRIPTION
## Summary
- Extends AlgoMotionDB schema (v2) with `projects` table for dashboard project listing
- Adds `project-persistence` module with IndexedDB CRUD operations (saveProjectToIndex, listProjects, getProjectIndex, deleteProject)
- Implements `useAutoSave` hook with 5-second debounced auto-save when project is dirty
- Wires Ctrl+S shortcut to immediate `saveProject()` function
- Integrates auto-save into EditorLayout

## Test plan
- [x] 8 unit tests for project-persistence CRUD (save, list, get, delete, update, no-throw on missing)
- [x] 7 unit tests for useAutoSave (dirty detection, debounce, markSaved, manual saveProject)
- [x] All 560 existing tests pass
- [x] Biome lint + format clean
- [x] TypeScript strict type check clean

Closes #14

🤖 Generated with [Claude Code](https://claude.com/claude-code)