### PR TITLE
feat: implement dark mode and theme system (#11)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -138,5 +138,8 @@
 	}
 	body {
 		@apply bg-background text-foreground;
+		transition:
+			background-color 150ms ease,
+			color 150ms ease;
 	}
 }

--- a/src/components/editor/editor-layout.tsx
+++ b/src/components/editor/editor-layout.tsx
@@ -10,12 +10,14 @@ import { RightPanel } from '@/components/panels/right-panel';
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
 import { useAutoSave } from '@/hooks/use-auto-save';
 import { useGlobalShortcuts } from '@/hooks/use-global-shortcuts';
+import { useThemeSync } from '@/hooks/use-theme-sync';
 import { useUIStore } from '@/lib/stores/ui-store';
 import { Toolbar } from './toolbar';
 
 export function EditorLayout() {
 	useGlobalShortcuts();
 	useAutoSave();
+	useThemeSync();
 
 	const leftRef = usePanelRef();
 	const rightRef = usePanelRef();

--- a/src/components/editor/theme-toggle.test.tsx
+++ b/src/components/editor/theme-toggle.test.tsx
@@ -1,0 +1,73 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useUIStore } from '@/lib/stores/ui-store';
+import { ThemeToggle } from './theme-toggle';
+
+// Mock next-themes
+const mockSetTheme = vi.fn();
+let mockTheme = 'dark';
+
+vi.mock('next-themes', () => ({
+	useTheme: () => ({
+		theme: mockTheme,
+		setTheme: mockSetTheme,
+		resolvedTheme: mockTheme === 'system' ? 'dark' : mockTheme,
+		systemTheme: 'dark',
+	}),
+}));
+
+describe('ThemeToggle', () => {
+	beforeEach(() => {
+		mockTheme = 'dark';
+		mockSetTheme.mockClear();
+		useUIStore.getState().reset();
+	});
+
+	it('renders a theme toggle button', () => {
+		render(<ThemeToggle />);
+		expect(screen.getByRole('button', { name: /theme/i })).toBeDefined();
+	});
+
+	it('opens a dropdown with dark, light, and system options', async () => {
+		const user = userEvent.setup();
+		render(<ThemeToggle />);
+
+		await user.click(screen.getByRole('button', { name: /theme/i }));
+
+		expect(screen.getByRole('menuitem', { name: /dark/i })).toBeDefined();
+		expect(screen.getByRole('menuitem', { name: /light/i })).toBeDefined();
+		expect(screen.getByRole('menuitem', { name: /system/i })).toBeDefined();
+	});
+
+	it('calls setTheme on next-themes when selecting light', async () => {
+		const user = userEvent.setup();
+		render(<ThemeToggle />);
+
+		await user.click(screen.getByRole('button', { name: /theme/i }));
+		await user.click(screen.getByRole('menuitem', { name: /light/i }));
+
+		expect(mockSetTheme).toHaveBeenCalledWith('light');
+	});
+
+	it('updates UI store when selecting a theme', async () => {
+		const user = userEvent.setup();
+		render(<ThemeToggle />);
+
+		await user.click(screen.getByRole('button', { name: /theme/i }));
+		await user.click(screen.getByRole('menuitem', { name: /light/i }));
+
+		expect(useUIStore.getState().theme).toBe('light');
+	});
+
+	it('calls setTheme on next-themes when selecting system', async () => {
+		const user = userEvent.setup();
+		render(<ThemeToggle />);
+
+		await user.click(screen.getByRole('button', { name: /theme/i }));
+		await user.click(screen.getByRole('menuitem', { name: /system/i }));
+
+		expect(mockSetTheme).toHaveBeenCalledWith('system');
+		expect(useUIStore.getState().theme).toBe('system');
+	});
+});

--- a/src/components/editor/theme-toggle.tsx
+++ b/src/components/editor/theme-toggle.tsx
@@ -1,0 +1,49 @@
+'use client';
+
+import { Monitor, Moon, Sun } from 'lucide-react';
+import { useTheme } from 'next-themes';
+import { Button } from '@/components/ui/button';
+import {
+	DropdownMenu,
+	DropdownMenuContent,
+	DropdownMenuItem,
+	DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { useUIStore } from '@/lib/stores/ui-store';
+import type { ThemePreference } from '@/types';
+
+const THEME_OPTIONS: { value: ThemePreference; label: string; icon: typeof Sun }[] = [
+	{ value: 'light', label: 'Light', icon: Sun },
+	{ value: 'dark', label: 'Dark', icon: Moon },
+	{ value: 'system', label: 'System', icon: Monitor },
+];
+
+export function ThemeToggle() {
+	const { setTheme: setNextTheme, resolvedTheme } = useTheme();
+	const setStoreTheme = useUIStore((s) => s.setTheme);
+
+	function handleSelect(theme: ThemePreference) {
+		setStoreTheme(theme);
+		setNextTheme(theme);
+	}
+
+	const CurrentIcon = resolvedTheme === 'dark' ? Moon : Sun;
+
+	return (
+		<DropdownMenu>
+			<DropdownMenuTrigger asChild>
+				<Button variant="ghost" size="icon" className="h-8 w-8" aria-label="Toggle theme">
+					<CurrentIcon className="h-4 w-4" />
+				</Button>
+			</DropdownMenuTrigger>
+			<DropdownMenuContent align="end">
+				{THEME_OPTIONS.map(({ value, label, icon: Icon }) => (
+					<DropdownMenuItem key={value} onSelect={() => handleSelect(value)}>
+						<Icon className="mr-2 h-4 w-4" />
+						{label}
+					</DropdownMenuItem>
+				))}
+			</DropdownMenuContent>
+		</DropdownMenu>
+	);
+}

--- a/src/components/editor/toolbar.tsx
+++ b/src/components/editor/toolbar.tsx
@@ -36,6 +36,7 @@ import { canRedo, canUndo, useHistoryStore } from '@/lib/stores/history-store';
 import { useSceneStore } from '@/lib/stores/scene-store';
 import { useTimelineStore } from '@/lib/stores/timeline-store';
 import type { PlaybackSpeed } from '@/types';
+import { ThemeToggle } from './theme-toggle';
 import { ToolSelector } from './tool-selector';
 
 function ToolbarButton({
@@ -219,6 +220,10 @@ export function Toolbar() {
 						))}
 					</DropdownMenuContent>
 				</DropdownMenu>
+
+				<Separator orientation="vertical" className="mx-1 h-5" />
+
+				<ThemeToggle />
 			</div>
 		</div>
 	);

--- a/src/components/shared/providers.tsx
+++ b/src/components/shared/providers.tsx
@@ -7,7 +7,7 @@ import { TooltipProvider } from '@/components/ui/tooltip';
 
 export function Providers({ children }: { children: ReactNode }) {
 	return (
-		<ThemeProvider attribute="class" defaultTheme="dark" enableSystem disableTransitionOnChange>
+		<ThemeProvider attribute="class" defaultTheme="dark" enableSystem>
 			<TooltipProvider delayDuration={300}>
 				{children}
 				<Toaster />

--- a/src/hooks/use-theme-sync.test.ts
+++ b/src/hooks/use-theme-sync.test.ts
@@ -1,0 +1,67 @@
+import { renderHook } from '@testing-library/react';
+import { act } from 'react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useUIStore } from '@/lib/stores/ui-store';
+import { useThemeSync } from './use-theme-sync';
+
+// Mock next-themes
+const mockSetTheme = vi.fn();
+let mockTheme = 'dark';
+
+vi.mock('next-themes', () => ({
+	useTheme: () => ({
+		theme: mockTheme,
+		setTheme: (t: string) => {
+			mockTheme = t;
+			mockSetTheme(t);
+		},
+		resolvedTheme: mockTheme === 'system' ? 'dark' : mockTheme,
+		systemTheme: 'dark',
+	}),
+}));
+
+describe('useThemeSync', () => {
+	beforeEach(() => {
+		mockTheme = 'dark';
+		mockSetTheme.mockClear();
+		useUIStore.getState().reset();
+	});
+
+	it('syncs UI store theme to next-themes on mount', () => {
+		act(() => {
+			useUIStore.getState().setTheme('light');
+		});
+
+		renderHook(() => useThemeSync());
+
+		expect(mockSetTheme).toHaveBeenCalledWith('light');
+	});
+
+	it('syncs default dark theme on mount', () => {
+		// UI store defaults to 'dark', mockTheme is 'dark'
+		renderHook(() => useThemeSync());
+
+		expect(mockSetTheme).toHaveBeenCalledWith('dark');
+	});
+
+	it('syncs system theme from store', () => {
+		act(() => {
+			useUIStore.getState().setTheme('system');
+		});
+
+		renderHook(() => useThemeSync());
+
+		expect(mockSetTheme).toHaveBeenCalledWith('system');
+	});
+
+	it('updates next-themes when UI store theme changes', () => {
+		renderHook(() => useThemeSync());
+		mockSetTheme.mockClear();
+
+		act(() => {
+			useUIStore.getState().setTheme('light');
+		});
+
+		expect(mockSetTheme).toHaveBeenCalledWith('light');
+	});
+});

--- a/src/hooks/use-theme-sync.ts
+++ b/src/hooks/use-theme-sync.ts
@@ -1,0 +1,32 @@
+import { useTheme } from 'next-themes';
+import { useEffect, useRef } from 'react';
+import { useUIStore } from '@/lib/stores/ui-store';
+
+/**
+ * Syncs the persisted UI store theme with next-themes.
+ *
+ * On mount, reads the theme from the UI store (persisted in IndexedDB)
+ * and applies it to next-themes. Also subscribes to UI store changes
+ * so that any setTheme() call is reflected in the DOM.
+ */
+export function useThemeSync(): void {
+	const { setTheme: setNextTheme } = useTheme();
+	const setNextThemeRef = useRef(setNextTheme);
+	setNextThemeRef.current = setNextTheme;
+
+	// On mount: sync persisted theme to next-themes
+	useEffect(() => {
+		const storeTheme = useUIStore.getState().theme;
+		setNextThemeRef.current(storeTheme);
+	}, []);
+
+	// Subscribe to UI store theme changes and forward to next-themes
+	useEffect(() => {
+		const unsubscribe = useUIStore.subscribe((state, prevState) => {
+			if (state.theme !== prevState.theme) {
+				setNextThemeRef.current(state.theme);
+			}
+		});
+		return unsubscribe;
+	}, []);
+}


### PR DESCRIPTION
## Summary
- Adds ThemeToggle dropdown in toolbar with dark/light/system options (Sun, Moon, Monitor icons)
- Implements useThemeSync hook to bridge persisted UI store theme with next-themes DOM management
- Enables 150ms CSS transition for smooth theme switching (removed `disableTransitionOnChange`)
- Theme persists across sessions via Zustand → Dexie.js IndexedDB, synced to next-themes on mount

## Test plan
- [x] 5 unit tests for ThemeToggle (renders, dropdown options, calls setTheme on both stores)
- [x] 4 unit tests for useThemeSync (mount sync, subscription forwarding)
- [x] All 569 existing tests pass
- [x] Biome lint + format clean
- [x] TypeScript strict type check clean

Closes #11

🤖 Generated with [Claude Code](https://claude.com/claude-code)