### PR TITLE
feat: implement command palette with fuzzy search (#12)

### DIFF
--- a/src/components/editor/command-palette.test.tsx
+++ b/src/components/editor/command-palette.test.tsx
@@ -1,0 +1,95 @@
+import { act, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { useUIStore } from '@/lib/stores/ui-store';
+import { CommandPalette } from './command-palette';
+
+// Mock next-themes (used by components in the tree)
+vi.mock('next-themes', () => ({
+	useTheme: () => ({
+		theme: 'dark',
+		setTheme: vi.fn(),
+		resolvedTheme: 'dark',
+		systemTheme: 'dark',
+	}),
+}));
+
+describe('CommandPalette', () => {
+	beforeEach(() => {
+		useUIStore.getState().reset();
+	});
+
+	it('does not render dialog content when closed', () => {
+		render(<CommandPalette />);
+		expect(screen.queryByPlaceholderText(/search/i)).toBeNull();
+	});
+
+	it('renders dialog content when open', () => {
+		act(() => {
+			useUIStore.getState().setCommandPaletteOpen(true);
+		});
+		render(<CommandPalette />);
+		expect(screen.getByPlaceholderText(/search/i)).toBeDefined();
+	});
+
+	it('shows command groups when open', () => {
+		act(() => {
+			useUIStore.getState().setCommandPaletteOpen(true);
+		});
+		render(<CommandPalette />);
+
+		// Should show at least the shortcut-based commands
+		expect(screen.getByText('Play / Pause')).toBeDefined();
+		expect(screen.getByText('Undo')).toBeDefined();
+	});
+
+	it('shows keyboard shortcuts inline', () => {
+		act(() => {
+			useUIStore.getState().setCommandPaletteOpen(true);
+		});
+		render(<CommandPalette />);
+
+		// Space shortcut for play/pause should be visible
+		expect(screen.getByText('Space')).toBeDefined();
+	});
+
+	it('closes the palette when Escape is pressed', async () => {
+		const user = userEvent.setup();
+		act(() => {
+			useUIStore.getState().setCommandPaletteOpen(true);
+		});
+		render(<CommandPalette />);
+
+		await user.keyboard('{Escape}');
+
+		expect(useUIStore.getState().commandPaletteOpen).toBe(false);
+	});
+
+	it('filters commands based on search input', async () => {
+		const user = userEvent.setup();
+		act(() => {
+			useUIStore.getState().setCommandPaletteOpen(true);
+		});
+		render(<CommandPalette />);
+
+		const input = screen.getByPlaceholderText(/search/i);
+		await user.type(input, 'zoom');
+
+		// Zoom commands should still be visible
+		expect(screen.getByText('Zoom In')).toBeDefined();
+		expect(screen.getByText('Zoom Out')).toBeDefined();
+	});
+
+	it('closes when a command is selected', async () => {
+		const user = userEvent.setup();
+		act(() => {
+			useUIStore.getState().setCommandPaletteOpen(true);
+		});
+		render(<CommandPalette />);
+
+		const item = screen.getByText('Toggle Grid');
+		await user.click(item);
+
+		expect(useUIStore.getState().commandPaletteOpen).toBe(false);
+	});
+});

--- a/src/components/editor/command-palette.tsx
+++ b/src/components/editor/command-palette.tsx
@@ -1,0 +1,101 @@
+'use client';
+
+import { useCallback } from 'react';
+import {
+	CommandDialog,
+	CommandEmpty,
+	CommandGroup,
+	CommandInput,
+	CommandItem,
+	CommandList,
+	CommandShortcut,
+} from '@/components/ui/command';
+import {
+	formatShortcut,
+	getShortcutsByCategory,
+	type ShortcutDefinition,
+} from '@/lib/shortcuts/shortcut-registry';
+import { useHistoryStore } from '@/lib/stores/history-store';
+import { useSceneStore } from '@/lib/stores/scene-store';
+import { useTimelineStore } from '@/lib/stores/timeline-store';
+import { useUIStore } from '@/lib/stores/ui-store';
+
+/**
+ * Returns action callbacks keyed by shortcut ID.
+ * Mirrors the actions in useGlobalShortcuts for consistency.
+ */
+function getActions(): Record<string, () => void> {
+	return {
+		'play-pause': () => {
+			const { playback, play, pause } = useTimelineStore.getState();
+			if (playback.status === 'playing') {
+				pause();
+			} else {
+				play();
+			}
+		},
+		undo: () => useHistoryStore.getState().undo(),
+		redo: () => useHistoryStore.getState().redo(),
+		save: () => {
+			// Triggers auto-save via store
+		},
+		'zoom-in': () => {
+			const { camera, setCamera } = useSceneStore.getState();
+			setCamera({ zoom: Math.min(camera.zoom + 0.25, 5) });
+		},
+		'zoom-out': () => {
+			const { camera, setCamera } = useSceneStore.getState();
+			setCamera({ zoom: Math.max(camera.zoom - 0.25, 0.1) });
+		},
+		'fit-to-screen': () => {
+			useSceneStore.getState().setCamera({ zoom: 1, x: 0, y: 0 });
+		},
+		'toggle-grid': () => useUIStore.getState().toggleGrid(),
+		'toggle-left-panel': () => useUIStore.getState().togglePanel('left'),
+		'toggle-right-panel': () => useUIStore.getState().togglePanel('right'),
+		'toggle-bottom-panel': () => useUIStore.getState().togglePanel('bottom'),
+	};
+}
+
+export function CommandPalette() {
+	const open = useUIStore((s) => s.commandPaletteOpen);
+	const setOpen = useUIStore((s) => s.setCommandPaletteOpen);
+	const grouped = getShortcutsByCategory();
+	const actions = getActions();
+
+	const handleSelect = useCallback(
+		(shortcut: ShortcutDefinition) => {
+			const action = actions[shortcut.id];
+			if (action) {
+				action();
+			}
+			setOpen(false);
+		},
+		[actions, setOpen],
+	);
+
+	return (
+		<CommandDialog open={open} onOpenChange={setOpen}>
+			<CommandInput placeholder="Search commands..." />
+			<CommandList>
+				<CommandEmpty>No commands found.</CommandEmpty>
+				{Object.entries(grouped).map(([category, shortcuts]) => (
+					<CommandGroup key={category} heading={category}>
+						{shortcuts.map((shortcut) => (
+							<CommandItem
+								key={shortcut.id}
+								value={shortcut.label}
+								onSelect={() => handleSelect(shortcut)}
+							>
+								{shortcut.label}
+								<CommandShortcut>
+									{shortcut.displayShortcut ?? formatShortcut(shortcut.keys)}
+								</CommandShortcut>
+							</CommandItem>
+						))}
+					</CommandGroup>
+				))}
+			</CommandList>
+		</CommandDialog>
+	);
+}

--- a/src/components/editor/editor-layout.tsx
+++ b/src/components/editor/editor-layout.tsx
@@ -12,6 +12,7 @@ import { useAutoSave } from '@/hooks/use-auto-save';
 import { useGlobalShortcuts } from '@/hooks/use-global-shortcuts';
 import { useThemeSync } from '@/hooks/use-theme-sync';
 import { useUIStore } from '@/lib/stores/ui-store';
+import { CommandPalette } from './command-palette';
 import { Toolbar } from './toolbar';
 
 export function EditorLayout() {
@@ -82,6 +83,7 @@ export function EditorLayout() {
 	return (
 		<div className="flex h-screen flex-col overflow-hidden">
 			<Toolbar />
+			<CommandPalette />
 			<ResizablePanelGroup orientation="horizontal" className="flex-1">
 				<ResizablePanel
 					id="left-panel"

--- a/src/hooks/use-global-shortcuts.ts
+++ b/src/hooks/use-global-shortcuts.ts
@@ -60,6 +60,7 @@ function getActions(): Record<string, () => void> {
 		'toggle-left-panel': () => useUIStore.getState().togglePanel('left'),
 		'toggle-right-panel': () => useUIStore.getState().togglePanel('right'),
 		'toggle-bottom-panel': () => useUIStore.getState().togglePanel('bottom'),
+		'command-palette': () => useUIStore.getState().toggleCommandPalette(),
 	};
 }
 

--- a/src/lib/shortcuts/shortcut-registry.ts
+++ b/src/lib/shortcuts/shortcut-registry.ts
@@ -138,4 +138,12 @@ export const shortcutRegistry: ShortcutDefinition[] = [
 		category: 'View',
 		keys: { key: '`', mod: true },
 	},
+
+	// General
+	{
+		id: 'command-palette',
+		label: 'Command Palette',
+		category: 'General',
+		keys: { key: 'k', mod: true },
+	},
 ];

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,2 +1,16 @@
 import 'fake-indexeddb/auto';
 import '@testing-library/jest-dom/vitest';
+
+// jsdom doesn't provide ResizeObserver or Element.scrollIntoView
+// which cmdk and radix-ui require
+if (typeof globalThis.ResizeObserver === 'undefined') {
+	globalThis.ResizeObserver = class ResizeObserver {
+		observe() {}
+		unobserve() {}
+		disconnect() {}
+	};
+}
+
+if (typeof Element.prototype.scrollIntoView === 'undefined') {
+	Element.prototype.scrollIntoView = () => {};
+}


### PR DESCRIPTION
## Summary
- Adds Ctrl+K command palette using shadcn/ui `CommandDialog` (wrapping `cmdk`)
- Populates commands from the existing `shortcutRegistry` grouped by category
- Fuzzy search, keyboard shortcuts shown inline, Escape to dismiss
- Selecting a command executes the action and closes the palette
- Adds `command-palette` shortcut to registry, wires Ctrl+K in `useGlobalShortcuts`

## Test plan
- [x] 7 unit tests for CommandPalette (render, open/close, search, shortcut display, command execution)
- [x] Added jsdom mocks for ResizeObserver and scrollIntoView (cmdk compatibility)
- [x] All 576 existing tests pass
- [x] Biome lint + format clean
- [x] TypeScript strict type check clean

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)