### PR TITLE
feat: build element library panel with categorized drag-and-drop (#15)

### DIFF
--- a/src/components/panels/element-library.test.tsx
+++ b/src/components/panels/element-library.test.tsx
@@ -1,0 +1,129 @@
+import { fireEvent, render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { ELEMENT_CATALOG } from '@/lib/element-library/element-catalog';
+import { ElementLibrary } from './element-library';
+
+// Mock next-themes
+vi.mock('next-themes', () => ({
+	useTheme: () => ({
+		theme: 'dark',
+		setTheme: vi.fn(),
+		resolvedTheme: 'dark',
+		systemTheme: 'dark',
+	}),
+}));
+
+describe('ElementLibrary', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('renders all category headings', () => {
+		render(<ElementLibrary />);
+		for (const category of ELEMENT_CATALOG) {
+			expect(screen.getByText(category.label)).toBeDefined();
+		}
+	});
+
+	it('renders search input', () => {
+		render(<ElementLibrary />);
+		expect(screen.getByPlaceholderText(/search elements/i)).toBeDefined();
+	});
+
+	it('shows enabled categories expanded by default', () => {
+		render(<ElementLibrary />);
+		const enabledCategories = ELEMENT_CATALOG.filter((c) => c.enabled);
+		for (const category of enabledCategories) {
+			// Items from enabled categories should be visible
+			for (const item of category.items) {
+				expect(screen.getByText(item.label)).toBeDefined();
+			}
+		}
+	});
+
+	it('shows disabled reason badge on disabled categories', () => {
+		render(<ElementLibrary />);
+		const disabledReasons = [
+			...new Set(
+				ELEMENT_CATALOG.filter((c) => !c.enabled && c.disabledReason).map((c) => c.disabledReason!),
+			),
+		];
+		for (const reason of disabledReasons) {
+			expect(screen.getAllByText(reason).length).toBeGreaterThan(0);
+		}
+	});
+
+	it('does not show items from disabled categories', () => {
+		render(<ElementLibrary />);
+		const disabledCategories = ELEMENT_CATALOG.filter((c) => !c.enabled);
+		for (const category of disabledCategories) {
+			for (const item of category.items) {
+				expect(screen.queryByText(item.label)).toBeNull();
+			}
+		}
+	});
+
+	it('filters elements by search query', async () => {
+		const user = userEvent.setup();
+		render(<ElementLibrary />);
+
+		const input = screen.getByPlaceholderText(/search elements/i);
+		await user.type(input, 'arrow');
+
+		// Arrow should be visible
+		expect(screen.getByText('Arrow')).toBeDefined();
+		// Node should not be visible
+		expect(screen.queryByText('Node')).toBeNull();
+	});
+
+	it('shows "No elements found" when search has no results', async () => {
+		const user = userEvent.setup();
+		render(<ElementLibrary />);
+
+		const input = screen.getByPlaceholderText(/search elements/i);
+		await user.type(input, 'xyznonexistent');
+
+		expect(screen.getByText(/no elements found/i)).toBeDefined();
+	});
+
+	it('does not search disabled categories', async () => {
+		const user = userEvent.setup();
+		render(<ElementLibrary />);
+
+		const input = screen.getByPlaceholderText(/search elements/i);
+		// "Array Cell" is in disabled Data Structures category
+		await user.type(input, 'array');
+
+		expect(screen.queryByText('Array Cell')).toBeNull();
+	});
+
+	it('makes enabled element items draggable', () => {
+		render(<ElementLibrary />);
+		const nodeElement = screen.getByText('Node').closest('[draggable]');
+		expect(nodeElement).toBeDefined();
+		expect(nodeElement?.getAttribute('draggable')).toBe('true');
+	});
+
+	it('sets element type in dataTransfer on drag start', () => {
+		render(<ElementLibrary />);
+		const nodeElement = screen.getByText('Node').closest('[draggable]');
+		expect(nodeElement).toBeDefined();
+
+		const setDataMock = vi.fn();
+		fireEvent.dragStart(nodeElement!, {
+			dataTransfer: {
+				setData: setDataMock,
+				effectAllowed: '',
+			},
+		});
+
+		expect(setDataMock).toHaveBeenCalledWith('application/algomotion-element', 'node');
+	});
+
+	it('shows element count per enabled category', () => {
+		render(<ElementLibrary />);
+		const primitives = ELEMENT_CATALOG.find((c) => c.id === 'primitives')!;
+		expect(screen.getByText(String(primitives.items.length))).toBeDefined();
+	});
+});

--- a/src/components/panels/element-library.tsx
+++ b/src/components/panels/element-library.tsx
@@ -1,0 +1,139 @@
+'use client';
+
+import { Search } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import {
+	Accordion,
+	AccordionContent,
+	AccordionItem,
+	AccordionTrigger,
+} from '@/components/ui/accordion';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import {
+	ELEMENT_CATALOG,
+	type LibraryCategory,
+	type LibraryItem,
+} from '@/lib/element-library/element-catalog';
+
+const DRAG_MIME_TYPE = 'application/algomotion-element';
+
+function ElementCard({ item }: { item: LibraryItem }) {
+	const Icon = item.icon;
+
+	function handleDragStart(e: React.DragEvent) {
+		e.dataTransfer.setData(DRAG_MIME_TYPE, item.type);
+		e.dataTransfer.effectAllowed = 'copy';
+	}
+
+	return (
+		// biome-ignore lint/a11y/useSemanticElements: draggable cards need div, not button — button interferes with drag behavior
+		<div
+			role="button"
+			tabIndex={0}
+			draggable
+			onDragStart={handleDragStart}
+			className="flex cursor-grab flex-col items-center gap-1.5 rounded-md border border-transparent p-2 text-center transition-colors hover:border-border hover:bg-accent active:cursor-grabbing"
+		>
+			<Icon className="h-6 w-6 text-muted-foreground" />
+			<span className="text-[10px] leading-tight text-muted-foreground">{item.label}</span>
+		</div>
+	);
+}
+
+function CategorySection({ category }: { category: LibraryCategory }) {
+	if (!category.enabled) {
+		return (
+			<div className="flex items-center justify-between px-3 py-2">
+				<span className="text-xs font-medium text-muted-foreground/60">{category.label}</span>
+				{category.disabledReason && (
+					<Badge variant="outline" className="text-[10px] text-muted-foreground/60">
+						{category.disabledReason}
+					</Badge>
+				)}
+			</div>
+		);
+	}
+
+	return (
+		<AccordionItem value={category.id}>
+			<AccordionTrigger className="px-3 py-2 text-xs">
+				<span className="flex items-center gap-2">
+					{category.label}
+					<Badge variant="secondary" className="h-4 px-1.5 text-[10px]">
+						{category.items.length}
+					</Badge>
+				</span>
+			</AccordionTrigger>
+			<AccordionContent className="px-2 pb-2">
+				<div className="grid grid-cols-3 gap-1">
+					{category.items.map((item) => (
+						<ElementCard key={item.type} item={item} />
+					))}
+				</div>
+			</AccordionContent>
+		</AccordionItem>
+	);
+}
+
+export function ElementLibrary() {
+	const [search, setSearch] = useState('');
+
+	const filteredCatalog = useMemo(() => {
+		const query = search.toLowerCase().trim();
+		if (!query) return ELEMENT_CATALOG;
+
+		return ELEMENT_CATALOG.map((category) => {
+			if (!category.enabled) return { ...category, items: [] };
+			const matchedItems = category.items.filter((item) =>
+				item.label.toLowerCase().includes(query),
+			);
+			return { ...category, items: matchedItems };
+		});
+	}, [search]);
+
+	const enabledCategories = filteredCatalog.filter((c) => c.enabled);
+	const disabledCategories = filteredCatalog.filter((c) => !c.enabled);
+	const hasResults = enabledCategories.some((c) => c.items.length > 0);
+	const defaultOpen = enabledCategories.filter((c) => c.items.length > 0).map((c) => c.id);
+
+	return (
+		<div className="flex h-full flex-col">
+			<div className="border-b p-2">
+				<div className="relative">
+					<Search className="absolute top-1/2 left-2.5 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+					<Input
+						placeholder="Search elements..."
+						value={search}
+						onChange={(e) => setSearch(e.target.value)}
+						className="h-7 pl-8 text-xs"
+					/>
+				</div>
+			</div>
+
+			<div className="flex-1 overflow-y-auto">
+				{hasResults ? (
+					<Accordion type="multiple" defaultValue={defaultOpen}>
+						{enabledCategories
+							.filter((c) => c.items.length > 0)
+							.map((category) => (
+								<CategorySection key={category.id} category={category} />
+							))}
+					</Accordion>
+				) : (
+					<div className="flex items-center justify-center p-8">
+						<p className="text-xs text-muted-foreground">No elements found</p>
+					</div>
+				)}
+
+				{!search && disabledCategories.length > 0 && (
+					<div className="border-t">
+						{disabledCategories.map((category) => (
+							<CategorySection key={category.id} category={category} />
+						))}
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/src/components/panels/left-panel.tsx
+++ b/src/components/panels/left-panel.tsx
@@ -1,9 +1,10 @@
 'use client';
 
-import { Blocks, Layers, LayoutTemplate } from 'lucide-react';
+import { Layers, LayoutTemplate } from 'lucide-react';
 import { EmptyState } from '@/components/shared/empty-state';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { ElementLibrary } from './element-library';
 
 export function LeftPanel() {
 	return (
@@ -20,12 +21,8 @@ export function LeftPanel() {
 				</TabsTrigger>
 			</TabsList>
 			<ScrollArea className="flex-1">
-				<TabsContent value="elements" className="mt-0">
-					<EmptyState
-						icon={Blocks}
-						title="No elements yet"
-						description="Drag elements from here onto the canvas"
-					/>
+				<TabsContent value="elements" className="mt-0 h-full">
+					<ElementLibrary />
 				</TabsContent>
 				<TabsContent value="templates" className="mt-0">
 					<EmptyState

--- a/src/lib/element-library/element-catalog.ts
+++ b/src/lib/element-library/element-catalog.ts
@@ -1,0 +1,109 @@
+import type { LucideIcon } from 'lucide-react';
+import {
+	ArrowRight,
+	Braces,
+	Circle,
+	Code,
+	GitGraph,
+	Grid2x2,
+	Hash,
+	Highlighter,
+	Image,
+	Link,
+	List,
+	MessageSquare,
+	Minus,
+	RectangleHorizontal,
+	Square,
+	Type,
+} from 'lucide-react';
+import type { ElementType } from '@/types/elements';
+
+export interface LibraryItem {
+	type: ElementType;
+	label: string;
+	icon: LucideIcon;
+}
+
+export interface LibraryCategory {
+	id: string;
+	label: string;
+	enabled: boolean;
+	disabledReason?: string;
+	items: LibraryItem[];
+}
+
+export const ELEMENT_CATALOG: LibraryCategory[] = [
+	{
+		id: 'primitives',
+		label: 'Primitives',
+		enabled: true,
+		items: [
+			{ type: 'node', label: 'Node', icon: Circle },
+			{ type: 'edge', label: 'Edge', icon: Minus },
+			{ type: 'arrow', label: 'Arrow', icon: ArrowRight },
+			{ type: 'rect', label: 'Rectangle', icon: Square },
+			{ type: 'ellipse', label: 'Ellipse', icon: Circle },
+			{ type: 'text', label: 'Text', icon: Type },
+			{ type: 'image', label: 'Image', icon: Image },
+		],
+	},
+	{
+		id: 'data-structures',
+		label: 'Data Structures',
+		enabled: false,
+		disabledReason: 'Coming in Phase 2',
+		items: [
+			{ type: 'arrayCell', label: 'Array Cell', icon: Grid2x2 },
+			{ type: 'linkedListNode', label: 'Linked List Node', icon: List },
+			{ type: 'stackFrame', label: 'Stack Frame', icon: RectangleHorizontal },
+			{ type: 'heapBlock', label: 'Heap Block', icon: Square },
+			{ type: 'treeNode', label: 'Tree Node', icon: GitGraph },
+			{ type: 'graphNode', label: 'Graph Node', icon: Circle },
+			{ type: 'hashBucket', label: 'Hash Bucket', icon: Hash },
+			{ type: 'pointerArrow', label: 'Pointer Arrow', icon: Link },
+		],
+	},
+	{
+		id: 'architecture',
+		label: 'Architecture',
+		enabled: false,
+		disabledReason: 'Coming in Phase 4',
+		items: [
+			{ type: 'register', label: 'Register', icon: Square },
+			{ type: 'aluUnit', label: 'ALU Unit', icon: Square },
+			{ type: 'cacheLine', label: 'Cache Line', icon: Grid2x2 },
+			{ type: 'memoryWord', label: 'Memory Word', icon: RectangleHorizontal },
+			{ type: 'bus', label: 'Bus', icon: Minus },
+			{ type: 'pipelineStage', label: 'Pipeline Stage', icon: ArrowRight },
+			{ type: 'controlUnit', label: 'Control Unit', icon: Square },
+			{ type: 'mux', label: 'Multiplexer', icon: GitGraph },
+			{ type: 'decoder', label: 'Decoder', icon: Code },
+			{ type: 'flipFlop', label: 'Flip-Flop', icon: Square },
+		],
+	},
+	{
+		id: 'math',
+		label: 'Math',
+		enabled: false,
+		disabledReason: 'Coming in Phase 4',
+		items: [
+			{ type: 'coordinatePlane', label: 'Coordinate Plane', icon: Grid2x2 },
+			{ type: 'vector', label: 'Vector', icon: ArrowRight },
+			{ type: 'matrix', label: 'Matrix', icon: Grid2x2 },
+			{ type: 'numberLine', label: 'Number Line', icon: Minus },
+			{ type: 'equation', label: 'Equation', icon: Type },
+		],
+	},
+	{
+		id: 'annotations',
+		label: 'Annotations',
+		enabled: true,
+		items: [
+			{ type: 'callout', label: 'Callout', icon: MessageSquare },
+			{ type: 'bracket', label: 'Bracket', icon: Braces },
+			{ type: 'highlightRegion', label: 'Highlight Region', icon: Highlighter },
+			{ type: 'codeSnippet', label: 'Code Snippet', icon: Code },
+		],
+	},
+];


### PR DESCRIPTION
## Summary
- Adds Element Library to left panel with 5 categorized sections using shadcn/ui Accordion
- Implements search/filter for quickly finding elements across categories
- Enables HTML5 drag-and-drop with custom MIME type (`application/algomotion-element`) for future canvas integration
- Shows "Coming Soon" badges on disabled categories (Data Structures in Phase 2, Architecture/Math in Phase 4)
- Replaces the empty state placeholder in the Elements tab with the full library

## Files Changed
- `src/lib/element-library/element-catalog.ts` — Central catalog defining all element categories and items
- `src/components/panels/element-library.tsx` — ElementLibrary component with accordion, grid, search, drag
- `src/components/panels/element-library.test.tsx` — 11 tests covering rendering, filtering, drag behavior
- `src/components/panels/left-panel.tsx` — Wires ElementLibrary into the Elements tab

## Test plan
- [x] All 5 category headings render
- [x] Enabled categories (Primitives, Annotations) show elements expanded
- [x] Disabled categories show reason badge, hide items
- [x] Search filters elements across enabled categories only
- [x] "No elements found" appears for empty search results
- [x] Element cards are draggable with correct MIME data
- [x] Element count badge shown per category
- [x] 587 total tests pass (11 new)

Closes #15

🤖 Generated with [Claude Code](https://claude.com/claude-code)