### PR TITLE
feat: build timeline UI with playback controls and scrubber (#27)

### DIFF
--- a/src/components/panels/bottom-panel.tsx
+++ b/src/components/panels/bottom-panel.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { Code, FileCode2, SlidersHorizontal, Terminal } from 'lucide-react';
+import { Code, FileCode2, Terminal } from 'lucide-react';
 import { EmptyState } from '@/components/shared/empty-state';
+import { TimelinePanel } from '@/components/timeline/timeline-panel';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
@@ -22,14 +23,10 @@ export function BottomPanel() {
 					DSL
 				</TabsTrigger>
 			</TabsList>
+			<TabsContent value="timeline" className="mt-0 h-full">
+				<TimelinePanel />
+			</TabsContent>
 			<ScrollArea className="flex-1">
-				<TabsContent value="timeline" className="mt-0">
-					<EmptyState
-						icon={SlidersHorizontal}
-						title="Timeline"
-						description="Animation timeline with keyframes and scrubber"
-					/>
-				</TabsContent>
 				<TabsContent value="code" className="mt-0">
 					<EmptyState
 						icon={Code}

--- a/src/components/timeline/playback-controls.test.tsx
+++ b/src/components/timeline/playback-controls.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { PlaybackControls } from './playback-controls';
+
+// Mock the timeline store
+const mockPlay = vi.fn();
+const mockPause = vi.fn();
+const mockStop = vi.fn();
+const mockSetSpeed = vi.fn();
+const mockToggleLoop = vi.fn();
+const mockSeek = vi.fn();
+
+vi.mock('@/lib/stores/timeline-store', () => ({
+	useTimelineStore: vi.fn((selector) =>
+		selector({
+			playback: { status: 'idle', speed: 1, currentTime: 0, loop: false },
+			duration: 10,
+			play: mockPlay,
+			pause: mockPause,
+			stop: mockStop,
+			setSpeed: mockSetSpeed,
+			toggleLoop: mockToggleLoop,
+			seek: mockSeek,
+		}),
+	),
+}));
+
+// Mock next-themes
+vi.mock('next-themes', () => ({
+	useTheme: () => ({
+		theme: 'dark',
+		setTheme: vi.fn(),
+		resolvedTheme: 'dark',
+		systemTheme: 'dark',
+	}),
+}));
+
+describe('PlaybackControls', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('renders play button when idle', () => {
+		render(<PlaybackControls />);
+		expect(screen.getByLabelText('Play')).toBeDefined();
+	});
+
+	it('calls play when play button is clicked', async () => {
+		const user = userEvent.setup();
+		render(<PlaybackControls />);
+		await user.click(screen.getByLabelText('Play'));
+		expect(mockPlay).toHaveBeenCalledTimes(1);
+	});
+
+	it('renders stop button', () => {
+		render(<PlaybackControls />);
+		expect(screen.getByLabelText('Stop')).toBeDefined();
+	});
+
+	it('calls stop when stop button is clicked', async () => {
+		const user = userEvent.setup();
+		render(<PlaybackControls />);
+		await user.click(screen.getByLabelText('Stop'));
+		expect(mockStop).toHaveBeenCalledTimes(1);
+	});
+
+	it('renders loop toggle', () => {
+		render(<PlaybackControls />);
+		expect(screen.getByLabelText('Toggle loop')).toBeDefined();
+	});
+
+	it('calls toggleLoop when loop button is clicked', async () => {
+		const user = userEvent.setup();
+		render(<PlaybackControls />);
+		await user.click(screen.getByLabelText('Toggle loop'));
+		expect(mockToggleLoop).toHaveBeenCalledTimes(1);
+	});
+
+	it('renders step forward button', () => {
+		render(<PlaybackControls />);
+		expect(screen.getByLabelText('Step forward')).toBeDefined();
+	});
+
+	it('renders step backward button', () => {
+		render(<PlaybackControls />);
+		expect(screen.getByLabelText('Step backward')).toBeDefined();
+	});
+
+	it('renders speed selector showing current speed', () => {
+		render(<PlaybackControls />);
+		expect(screen.getByText('1x')).toBeDefined();
+	});
+
+	it('displays current time', () => {
+		render(<PlaybackControls />);
+		expect(screen.getByText('0:00')).toBeDefined();
+	});
+});

--- a/src/components/timeline/playback-controls.tsx
+++ b/src/components/timeline/playback-controls.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { Pause, Play, Repeat, SkipBack, SkipForward, Square } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from '@/components/ui/select';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip';
+import { useTimelineStore } from '@/lib/stores/timeline-store';
+import type { PlaybackSpeed } from '@/types';
+
+const SPEEDS: PlaybackSpeed[] = [0.25, 0.5, 1, 1.5, 2, 4];
+const STEP_SIZE = 0.1; // seconds per step
+
+function formatTime(seconds: number): string {
+	const mins = Math.floor(seconds / 60);
+	const secs = Math.floor(seconds % 60);
+	const frames = Math.floor((seconds % 1) * 100);
+	if (mins > 0) {
+		return `${mins}:${String(secs).padStart(2, '0')}`;
+	}
+	return `${secs}:${String(frames).padStart(2, '0')}`;
+}
+
+export function PlaybackControls() {
+	const status = useTimelineStore((s) => s.playback.status);
+	const speed = useTimelineStore((s) => s.playback.speed);
+	const currentTime = useTimelineStore((s) => s.playback.currentTime);
+	const loop = useTimelineStore((s) => s.playback.loop);
+	const duration = useTimelineStore((s) => s.duration);
+	const play = useTimelineStore((s) => s.play);
+	const pause = useTimelineStore((s) => s.pause);
+	const stop = useTimelineStore((s) => s.stop);
+	const seek = useTimelineStore((s) => s.seek);
+	const setSpeed = useTimelineStore((s) => s.setSpeed);
+	const toggleLoop = useTimelineStore((s) => s.toggleLoop);
+
+	const isPlaying = status === 'playing';
+
+	function handlePlayPause() {
+		if (isPlaying) {
+			pause();
+		} else {
+			play();
+		}
+	}
+
+	function handleStepBackward() {
+		seek(Math.max(0, currentTime - STEP_SIZE));
+	}
+
+	function handleStepForward() {
+		seek(Math.min(duration, currentTime + STEP_SIZE));
+	}
+
+	return (
+		<TooltipProvider delayDuration={300}>
+			<div className="flex items-center gap-1">
+				{/* Time display */}
+				<span className="min-w-[48px] text-right font-mono text-xs text-muted-foreground">
+					{formatTime(currentTime)}
+				</span>
+
+				<div className="mx-1 h-4 w-px bg-border" />
+
+				{/* Step backward */}
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							variant="ghost"
+							size="icon"
+							className="h-6 w-6"
+							onClick={handleStepBackward}
+							aria-label="Step backward"
+						>
+							<SkipBack className="h-3.5 w-3.5" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>Step backward</TooltipContent>
+				</Tooltip>
+
+				{/* Stop */}
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							variant="ghost"
+							size="icon"
+							className="h-6 w-6"
+							onClick={stop}
+							aria-label="Stop"
+						>
+							<Square className="h-3 w-3" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>Stop</TooltipContent>
+				</Tooltip>
+
+				{/* Play / Pause */}
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							variant="ghost"
+							size="icon"
+							className="h-7 w-7"
+							onClick={handlePlayPause}
+							aria-label={isPlaying ? 'Pause' : 'Play'}
+						>
+							{isPlaying ? <Pause className="h-4 w-4" /> : <Play className="h-4 w-4" />}
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>{isPlaying ? 'Pause' : 'Play'}</TooltipContent>
+				</Tooltip>
+
+				{/* Step forward */}
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							variant="ghost"
+							size="icon"
+							className="h-6 w-6"
+							onClick={handleStepForward}
+							aria-label="Step forward"
+						>
+							<SkipForward className="h-3.5 w-3.5" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>Step forward</TooltipContent>
+				</Tooltip>
+
+				<div className="mx-1 h-4 w-px bg-border" />
+
+				{/* Loop toggle */}
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							variant={loop ? 'secondary' : 'ghost'}
+							size="icon"
+							className="h-6 w-6"
+							onClick={toggleLoop}
+							aria-label="Toggle loop"
+						>
+							<Repeat className="h-3.5 w-3.5" />
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent>Toggle loop</TooltipContent>
+				</Tooltip>
+
+				{/* Speed selector */}
+				<Select value={String(speed)} onValueChange={(v) => setSpeed(Number(v) as PlaybackSpeed)}>
+					<SelectTrigger className="h-6 w-14 text-xs" aria-label="Playback speed">
+						<SelectValue />
+					</SelectTrigger>
+					<SelectContent>
+						{SPEEDS.map((s) => (
+							<SelectItem key={s} value={String(s)} className="text-xs">
+								{s}x
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+			</div>
+		</TooltipProvider>
+	);
+}

--- a/src/components/timeline/timeline-panel.tsx
+++ b/src/components/timeline/timeline-panel.tsx
@@ -1,0 +1,25 @@
+'use client';
+
+import { PlaybackControls } from './playback-controls';
+import { TimelineScrubber } from './timeline-scrubber';
+
+/**
+ * Main timeline panel combining playback controls and scrubber.
+ * Displayed in the bottom panel's Timeline tab.
+ */
+export function TimelinePanel() {
+	return (
+		<div className="flex h-full flex-col">
+			{/* Controls bar */}
+			<div className="flex items-center gap-2 border-b px-2 py-1">
+				<PlaybackControls />
+				<TimelineScrubber />
+			</div>
+
+			{/* Track area (placeholder for keyframe tracks) */}
+			<div className="flex flex-1 items-center justify-center">
+				<p className="text-xs text-muted-foreground/60">Select elements to view animation tracks</p>
+			</div>
+		</div>
+	);
+}

--- a/src/components/timeline/timeline-scrubber.test.tsx
+++ b/src/components/timeline/timeline-scrubber.test.tsx
@@ -1,0 +1,56 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TimelineScrubber } from './timeline-scrubber';
+
+// Mock the timeline store
+const mockSeek = vi.fn();
+
+vi.mock('@/lib/stores/timeline-store', () => ({
+	useTimelineStore: vi.fn((selector) =>
+		selector({
+			playback: { status: 'idle', speed: 1, currentTime: 3.5, loop: false },
+			duration: 10,
+			seek: mockSeek,
+		}),
+	),
+}));
+
+// Mock next-themes
+vi.mock('next-themes', () => ({
+	useTheme: () => ({
+		theme: 'dark',
+		setTheme: vi.fn(),
+		resolvedTheme: 'dark',
+		systemTheme: 'dark',
+	}),
+}));
+
+describe('TimelineScrubber', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('renders the scrubber track', () => {
+		render(<TimelineScrubber />);
+		expect(screen.getByRole('slider')).toBeDefined();
+	});
+
+	it('displays the slider with correct value', () => {
+		render(<TimelineScrubber />);
+		const slider = screen.getByRole('slider');
+		expect(slider.getAttribute('aria-valuenow')).toBe('3.5');
+	});
+
+	it('has correct min and max values', () => {
+		render(<TimelineScrubber />);
+		const slider = screen.getByRole('slider');
+		expect(slider.getAttribute('aria-valuemin')).toBe('0');
+		expect(slider.getAttribute('aria-valuemax')).toBe('10');
+	});
+
+	it('renders time ruler marks', () => {
+		render(<TimelineScrubber />);
+		// Should show time marks for a 10s timeline
+		expect(screen.getByText('0s')).toBeDefined();
+	});
+});

--- a/src/components/timeline/timeline-scrubber.tsx
+++ b/src/components/timeline/timeline-scrubber.tsx
@@ -1,0 +1,69 @@
+'use client';
+
+import { useMemo } from 'react';
+import { Slider } from '@/components/ui/slider';
+import { useTimelineStore } from '@/lib/stores/timeline-store';
+
+/**
+ * Generate time ruler marks for the timeline.
+ * Shows marks at 1s intervals for short timelines, 5s for longer ones.
+ */
+function generateTimeMarks(duration: number): { time: number; label: string }[] {
+	if (duration <= 0) return [{ time: 0, label: '0s' }];
+
+	const interval = duration <= 10 ? 1 : duration <= 60 ? 5 : 10;
+	const marks: { time: number; label: string }[] = [];
+
+	for (let t = 0; t <= duration; t += interval) {
+		marks.push({ time: t, label: `${t}s` });
+	}
+
+	return marks;
+}
+
+/**
+ * Timeline scrubber with draggable playhead and time ruler.
+ * Connects to the timeline store for seek operations.
+ */
+export function TimelineScrubber() {
+	const currentTime = useTimelineStore((s) => s.playback.currentTime);
+	const duration = useTimelineStore((s) => s.duration);
+	const seek = useTimelineStore((s) => s.seek);
+
+	const timeMarks = useMemo(() => generateTimeMarks(duration), [duration]);
+
+	function handleSeek(value: number[]) {
+		seek(value[0]);
+	}
+
+	return (
+		<div className="flex flex-1 flex-col gap-1">
+			{/* Time ruler */}
+			<div className="relative h-4 px-2">
+				{timeMarks.map((mark) => (
+					<span
+						key={mark.time}
+						className="absolute top-0 -translate-x-1/2 text-[9px] text-muted-foreground/60"
+						style={{
+							left: duration > 0 ? `${(mark.time / duration) * 100}%` : '0%',
+						}}
+					>
+						{mark.label}
+					</span>
+				))}
+			</div>
+
+			{/* Scrubber slider */}
+			<div className="px-2">
+				<Slider
+					value={[currentTime]}
+					min={0}
+					max={duration}
+					step={0.01}
+					onValueChange={handleSeek}
+					aria-label="Timeline scrubber"
+				/>
+			</div>
+		</div>
+	);
+}


### PR DESCRIPTION
## Summary
- **PlaybackControls**: Play/pause, stop, step forward/backward, loop toggle, speed selector (0.25x-4x), current time display — all connected to `useTimelineStore`
- **TimelineScrubber**: Draggable slider with time ruler marks (auto-scaled intervals), connected to store's `seek` action
- **TimelinePanel**: Combines controls + scrubber in a professional controls bar with placeholder track area
- **BottomPanel**: Replaced timeline empty state with live `TimelinePanel`

## Architecture
- All components use individual `useTimelineStore` selectors for minimal re-renders
- `formatTime()` shows minutes:seconds or seconds:frames format
- Time ruler marks auto-scale based on duration (1s intervals for ≤10s, 5s for ≤60s, 10s for longer)
- shadcn/ui primitives: Button, Select, Slider, Tooltip

## Test plan
- [x] 10 PlaybackControls tests (play button, play click, stop button, stop click, loop toggle, step forward/backward, speed selector, time display)
- [x] 4 TimelineScrubber tests (slider rendering, current value, min/max, time ruler marks)
- [x] All 650 existing tests pass
- [x] Biome lint + format clean
- [x] TypeScript strict mode clean

Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)