### PR TITLE
feat: implement linked list composite with animation presets (#22)

### DIFF
--- a/src/lib/gsap/presets/linked-list-presets.test.ts
+++ b/src/lib/gsap/presets/linked-list-presets.test.ts
@@ -1,0 +1,111 @@
+import gsap from 'gsap';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+	linkedListDelete,
+	linkedListInsert,
+	linkedListReverse,
+	linkedListSearch,
+	linkedListTraverse,
+} from './linked-list-presets';
+
+function createMockNodes(count: number) {
+	const nodes: Record<
+		string,
+		{
+			position: { x: number; y: number };
+			alpha: number;
+			scale: { x: number; y: number };
+			_fillColor: number;
+		}
+	> = {};
+
+	for (let i = 0; i < count; i++) {
+		nodes[`n${i + 1}`] = {
+			position: { x: i * 90, y: 0 },
+			alpha: 1,
+			scale: { x: 1, y: 1 },
+			_fillColor: 0x2a2a4a,
+		};
+	}
+
+	return nodes;
+}
+
+describe('Linked List Animation Presets', () => {
+	beforeEach(() => {
+		gsap.ticker.lagSmoothing(0);
+	});
+
+	afterEach(() => {
+		gsap.globalTimeline.clear();
+	});
+
+	describe('linkedListInsert', () => {
+		it('creates a timeline that fades in a new node', () => {
+			const newNode = {
+				position: { x: 180, y: 0 },
+				alpha: 0,
+				scale: { x: 0, y: 0 },
+				_fillColor: 0x2a2a4a,
+			};
+			const tl = linkedListInsert(newNode);
+
+			tl.progress(1);
+
+			expect(newNode.alpha).toBe(1);
+			expect(newNode.scale.x).toBeCloseTo(1);
+		});
+	});
+
+	describe('linkedListDelete', () => {
+		it('creates a timeline that fades out a node', () => {
+			const nodes = createMockNodes(3);
+			const tl = linkedListDelete(nodes.n2);
+
+			tl.progress(1);
+
+			expect(nodes.n2.alpha).toBe(0);
+		});
+	});
+
+	describe('linkedListTraverse', () => {
+		it('creates a timeline that highlights nodes sequentially', () => {
+			const nodes = createMockNodes(3);
+			const order = ['n1', 'n2', 'n3'];
+			const highlightColor = 0x3b82f6;
+
+			const tl = linkedListTraverse(nodes, order, highlightColor);
+
+			expect(tl).toBeDefined();
+			expect(tl.totalDuration()).toBeGreaterThan(0);
+		});
+	});
+
+	describe('linkedListReverse', () => {
+		it('creates a timeline with nonzero duration', () => {
+			const nodes = createMockNodes(3);
+			const order = ['n1', 'n2', 'n3'];
+
+			const tl = linkedListReverse(nodes, order);
+
+			expect(tl).toBeDefined();
+			expect(tl.totalDuration()).toBeGreaterThan(0);
+		});
+	});
+
+	describe('linkedListSearch', () => {
+		it('highlights nodes along the search path', () => {
+			const nodes = createMockNodes(3);
+			const path = ['n1', 'n2'];
+			const foundColor = 0x10b981;
+			const searchColor = 0x3b82f6;
+
+			const tl = linkedListSearch(nodes, path, 'n2', searchColor, foundColor);
+
+			tl.progress(1);
+
+			// Found node should have the found color
+			expect(nodes.n2._fillColor).toBe(foundColor);
+		});
+	});
+});

--- a/src/lib/gsap/presets/linked-list-presets.ts
+++ b/src/lib/gsap/presets/linked-list-presets.ts
@@ -1,0 +1,100 @@
+import gsap from 'gsap';
+
+interface AnimatableNode {
+	position: { x: number; y: number };
+	alpha: number;
+	scale: { x: number; y: number };
+	_fillColor: number;
+}
+
+/**
+ * Insert animation — fades in and scales up a new node.
+ * The node should start with alpha: 0 and scale: { x: 0, y: 0 }.
+ */
+export function linkedListInsert(newNode: AnimatableNode): gsap.core.Timeline {
+	const tl = gsap.timeline();
+
+	tl.to(newNode, { alpha: 1, duration: 0.2, ease: 'power1.out' }, 0);
+	tl.to(newNode.scale, { x: 1, y: 1, duration: 0.2, ease: 'back.out' }, 0);
+
+	return tl;
+}
+
+/**
+ * Delete animation — fades out and shrinks the target node.
+ */
+export function linkedListDelete(node: AnimatableNode): gsap.core.Timeline {
+	const tl = gsap.timeline();
+
+	tl.to(node, { alpha: 0, duration: 0.2, ease: 'power1.in' }, 0);
+	tl.to(node.scale, { x: 0.8, y: 0.8, duration: 0.2, ease: 'power1.in' }, 0);
+
+	return tl;
+}
+
+/**
+ * Traverse animation — highlights nodes sequentially along the list.
+ * Each node gets a color pulse and slight scale bounce in order.
+ */
+export function linkedListTraverse(
+	nodes: Record<string, AnimatableNode>,
+	order: string[],
+	highlightColor: number,
+): gsap.core.Timeline {
+	const tl = gsap.timeline();
+
+	for (let i = 0; i < order.length; i++) {
+		const node = nodes[order[i]];
+		const offset = i * 0.3;
+
+		tl.to(node, { _fillColor: highlightColor, duration: 0.2 }, offset);
+		tl.to(node.scale, { x: 1.1, y: 1.1, duration: 0.1, ease: 'power2.out' }, offset);
+		tl.to(node.scale, { x: 1, y: 1, duration: 0.1, ease: 'power2.in' }, offset + 0.1);
+	}
+
+	return tl;
+}
+
+/**
+ * Reverse animation — slides nodes to their new positions.
+ * Node at index i moves to position (length - 1 - i) * stride.
+ */
+export function linkedListReverse(
+	nodes: Record<string, AnimatableNode>,
+	order: string[],
+): gsap.core.Timeline {
+	const tl = gsap.timeline();
+	const stride = 90; // nodeWidth(60) + arrowGap(30)
+
+	for (let i = 0; i < order.length; i++) {
+		const node = nodes[order[i]];
+		const targetX = (order.length - 1 - i) * stride;
+
+		tl.to(node.position, { x: targetX, duration: 0.3, ease: 'power1.inOut' }, i * 0.1);
+	}
+
+	return tl;
+}
+
+/**
+ * Search animation — highlights nodes along the search path.
+ * Visited nodes get searchColor, the found node gets foundColor.
+ */
+export function linkedListSearch(
+	nodes: Record<string, AnimatableNode>,
+	path: string[],
+	foundId: string,
+	searchColor: number,
+	foundColor: number,
+): gsap.core.Timeline {
+	const tl = gsap.timeline();
+
+	for (let i = 0; i < path.length; i++) {
+		const node = nodes[path[i]];
+		const color = path[i] === foundId ? foundColor : searchColor;
+
+		tl.to(node, { _fillColor: color, duration: 0.2 }, i * 0.3);
+	}
+
+	return tl;
+}

--- a/src/lib/pixi/renderers/element-renderer.ts
+++ b/src/lib/pixi/renderers/element-renderer.ts
@@ -1,6 +1,7 @@
 import type { ArrowShape, SceneElement } from '@/types';
 import { ArrayRenderer } from './array-renderer';
 import { GraphRenderer } from './graph-renderer';
+import { LinkedListRenderer } from './linked-list-renderer';
 import { calculateArrowheadPoints, hexToPixiColor } from './shared';
 import { TreeRenderer } from './tree-renderer';
 
@@ -74,12 +75,14 @@ export class ElementRenderer {
 	private arrayRenderer: ArrayRenderer;
 	private treeRenderer: TreeRenderer;
 	private graphRenderer: GraphRenderer;
+	private linkedListRenderer: LinkedListRenderer;
 
 	constructor(pixi: PixiModule) {
 		this.pixi = pixi;
 		this.arrayRenderer = new ArrayRenderer(pixi as never);
 		this.treeRenderer = new TreeRenderer(pixi as never);
 		this.graphRenderer = new GraphRenderer(pixi as never);
+		this.linkedListRenderer = new LinkedListRenderer(pixi as never);
 	}
 
 	/**
@@ -115,6 +118,13 @@ export class ElementRenderer {
 	 */
 	getGraphEdgeGraphics(elementId: string): Map<string, unknown> | undefined {
 		return this.graphRenderer.getEdgeGraphics(elementId);
+	}
+
+	/**
+	 * Get linked list node containers for animation targeting.
+	 */
+	getLinkedListNodeContainers(elementId: string): Map<string, unknown> | undefined {
+		return this.linkedListRenderer.getNodeContainers(elementId);
 	}
 
 	/**
@@ -165,6 +175,11 @@ export class ElementRenderer {
 			case 'graphNode': {
 				const graphContainer = this.graphRenderer.render(element);
 				container.addChild(graphContainer);
+				break;
+			}
+			case 'linkedListNode': {
+				const llContainer = this.linkedListRenderer.render(element);
+				container.addChild(llContainer);
 				break;
 			}
 			default:
@@ -218,6 +233,11 @@ export class ElementRenderer {
 			case 'graphNode': {
 				const graphContainer = this.graphRenderer.render(element);
 				container.addChild(graphContainer);
+				break;
+			}
+			case 'linkedListNode': {
+				const llContainer = this.linkedListRenderer.render(element);
+				container.addChild(llContainer);
 				break;
 			}
 			default:

--- a/src/lib/pixi/renderers/linked-list-renderer.test.ts
+++ b/src/lib/pixi/renderers/linked-list-renderer.test.ts
@@ -1,0 +1,203 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SceneElement } from '@/types';
+import { LinkedListRenderer } from './linked-list-renderer';
+import { DEFAULT_ELEMENT_STYLE } from './shared';
+
+function createMockPixi() {
+	function MockContainer(this: Record<string, unknown>) {
+		const children: unknown[] = [];
+		this.addChild = vi.fn((...args: unknown[]) => children.push(...args));
+		this.removeChildren = vi.fn();
+		this.destroy = vi.fn();
+		this.position = { set: vi.fn(), x: 0, y: 0 };
+		this.alpha = 1;
+		this.angle = 0;
+		this.visible = true;
+		this.label = '';
+		this.cullable = false;
+		this.children = children;
+	}
+
+	function MockGraphics(this: Record<string, unknown>) {
+		this.clear = vi.fn().mockReturnThis();
+		this.rect = vi.fn().mockReturnThis();
+		this.roundRect = vi.fn().mockReturnThis();
+		this.circle = vi.fn().mockReturnThis();
+		this.fill = vi.fn().mockReturnThis();
+		this.stroke = vi.fn().mockReturnThis();
+		this.moveTo = vi.fn().mockReturnThis();
+		this.lineTo = vi.fn().mockReturnThis();
+		this.bezierCurveTo = vi.fn().mockReturnThis();
+		this.poly = vi.fn().mockReturnThis();
+		this.closePath = vi.fn().mockReturnThis();
+		this.destroy = vi.fn();
+	}
+
+	function MockText(this: Record<string, unknown>, opts: { text: string; style: unknown }) {
+		this.text = opts.text;
+		this.style = opts.style;
+		this.anchor = { set: vi.fn() };
+		this.position = { set: vi.fn() };
+		this.visible = true;
+		this.destroy = vi.fn();
+	}
+
+	function MockTextStyle(_opts: Record<string, unknown>) {
+		return { ..._opts };
+	}
+
+	return {
+		Container: vi.fn().mockImplementation(MockContainer),
+		Graphics: vi.fn().mockImplementation(MockGraphics),
+		Text: vi.fn().mockImplementation(MockText),
+		TextStyle: vi.fn().mockImplementation(MockTextStyle),
+	};
+}
+
+function makeLinkedListElement(overrides?: Partial<SceneElement>): SceneElement {
+	return {
+		id: 'list-1',
+		type: 'linkedListNode',
+		position: { x: 50, y: 100 },
+		size: { width: 400, height: 60 },
+		rotation: 0,
+		opacity: 1,
+		visible: true,
+		locked: false,
+		label: '',
+		style: {
+			...DEFAULT_ELEMENT_STYLE,
+			fill: '#2a2a4a',
+			stroke: '#6366f1',
+			cornerRadius: 4,
+			fontSize: 14,
+			fontFamily: 'JetBrains Mono, monospace',
+			fontWeight: 600,
+			textColor: '#e0e0f0',
+		},
+		metadata: {
+			nodes: [
+				{ id: 'n1', value: 10 },
+				{ id: 'n2', value: 20 },
+				{ id: 'n3', value: 30 },
+			],
+			nodeWidth: 60,
+			nodeHeight: 40,
+			arrowGap: 30,
+			highlightedNodes: [],
+			highlightColor: '#3b82f6',
+		},
+		...overrides,
+	};
+}
+
+describe('LinkedListRenderer', () => {
+	let pixi: ReturnType<typeof createMockPixi>;
+	let renderer: LinkedListRenderer;
+
+	beforeEach(() => {
+		pixi = createMockPixi();
+		renderer = new LinkedListRenderer(pixi as never);
+	});
+
+	it('renders node rectangles with value text and arrows', () => {
+		const element = makeLinkedListElement();
+		const container = renderer.render(element);
+
+		expect(container.addChild).toHaveBeenCalled();
+		// 3 nodes: each gets Graphics (rect) + Text (value) = 6
+		// 2 arrows between nodes = 2 Graphics
+		// 1 null terminator graphic = 1 Graphics
+		// Total: 9
+		const addChildCalls = (container.addChild as ReturnType<typeof vi.fn>).mock.calls;
+		expect(addChildCalls.length).toBe(9);
+	});
+
+	it('renders value text inside each node', () => {
+		const element = makeLinkedListElement();
+		renderer.render(element);
+
+		const textCalls = (pixi.Text as ReturnType<typeof vi.fn>).mock.calls;
+		expect(textCalls.length).toBe(3);
+		expect(textCalls[0][0].text).toBe('10');
+		expect(textCalls[1][0].text).toBe('20');
+		expect(textCalls[2][0].text).toBe('30');
+	});
+
+	it('positions nodes horizontally with arrow gaps', () => {
+		const element = makeLinkedListElement();
+		renderer.render(element);
+
+		const graphicsResults = (pixi.Graphics as ReturnType<typeof vi.fn>).mock.results;
+		// First 3 Graphics are node rects
+		for (let i = 0; i < 3; i++) {
+			const g = graphicsResults[i].value;
+			const expectedX = i * (60 + 30); // nodeWidth + arrowGap
+			expect(g.roundRect).toHaveBeenCalledWith(expectedX, 0, 60, 40, 4);
+		}
+	});
+
+	it('handles empty list', () => {
+		const element = makeLinkedListElement({
+			metadata: {
+				nodes: [],
+				nodeWidth: 60,
+				nodeHeight: 40,
+				arrowGap: 30,
+				highlightedNodes: [],
+				highlightColor: '#3b82f6',
+			},
+		});
+		const container = renderer.render(element);
+		expect(container.addChild).not.toHaveBeenCalled();
+	});
+
+	it('handles single-node list (no arrows)', () => {
+		const element = makeLinkedListElement({
+			metadata: {
+				nodes: [{ id: 'n1', value: 42 }],
+				nodeWidth: 60,
+				nodeHeight: 40,
+				arrowGap: 30,
+				highlightedNodes: [],
+				highlightColor: '#3b82f6',
+			},
+		});
+		const container = renderer.render(element);
+		// 1 node rect + 1 value text + 1 null terminator = 3
+		const addChildCalls = (container.addChild as ReturnType<typeof vi.fn>).mock.calls;
+		expect(addChildCalls.length).toBe(3);
+	});
+
+	it('applies highlight fill color to highlighted nodes', () => {
+		const element = makeLinkedListElement({
+			metadata: {
+				nodes: [
+					{ id: 'n1', value: 10 },
+					{ id: 'n2', value: 20 },
+				],
+				nodeWidth: 60,
+				nodeHeight: 40,
+				arrowGap: 30,
+				highlightedNodes: ['n2'],
+				highlightColor: '#3b82f6',
+			},
+		});
+		renderer.render(element);
+
+		const graphicsCalls = (pixi.Graphics as ReturnType<typeof vi.fn>).mock.results;
+		// Node 0: normal
+		expect(graphicsCalls[0].value.fill).toHaveBeenCalledWith({ color: 0x2a2a4a });
+		// Node 1: highlighted
+		expect(graphicsCalls[1].value.fill).toHaveBeenCalledWith({ color: 0x3b82f6 });
+	});
+
+	it('returns node containers for animation targeting', () => {
+		const element = makeLinkedListElement();
+		renderer.render(element);
+
+		const nodeContainers = renderer.getNodeContainers('list-1');
+		expect(nodeContainers).toBeDefined();
+		expect(nodeContainers?.size).toBe(3);
+	});
+});

--- a/src/lib/pixi/renderers/linked-list-renderer.ts
+++ b/src/lib/pixi/renderers/linked-list-renderer.ts
@@ -1,0 +1,179 @@
+import type { SceneElement } from '@/types';
+import { hexToPixiColor } from './shared';
+
+interface PixiContainer {
+	addChild(...children: unknown[]): void;
+	removeChildren(): void;
+	destroy(options?: { children: boolean }): void;
+	position: { set(x: number, y: number): void; x: number; y: number };
+	alpha: number;
+	angle: number;
+	visible: boolean;
+	label: string;
+	cullable: boolean;
+	children: unknown[];
+}
+
+interface PixiGraphics {
+	clear(): PixiGraphics;
+	rect(x: number, y: number, w: number, h: number): PixiGraphics;
+	roundRect(x: number, y: number, w: number, h: number, r: number): PixiGraphics;
+	circle(x: number, y: number, r: number): PixiGraphics;
+	fill(opts: { color: number; alpha?: number } | number): PixiGraphics;
+	stroke(opts: { width: number; color: number; alpha?: number }): PixiGraphics;
+	moveTo(x: number, y: number): PixiGraphics;
+	lineTo(x: number, y: number): PixiGraphics;
+	bezierCurveTo(
+		cp1x: number,
+		cp1y: number,
+		cp2x: number,
+		cp2y: number,
+		x: number,
+		y: number,
+	): PixiGraphics;
+	poly(points: number[]): PixiGraphics;
+	closePath(): PixiGraphics;
+	destroy(): void;
+}
+
+interface PixiText {
+	text: string;
+	style: Record<string, unknown>;
+	anchor: { set(x: number, y: number): void };
+	position: { set(x: number, y: number): void };
+	visible: boolean;
+	destroy(): void;
+}
+
+interface PixiModule {
+	Container: new () => PixiContainer;
+	Graphics: new () => PixiGraphics;
+	Text: new (opts: { text: string; style: unknown }) => PixiText;
+	TextStyle: new (opts: Record<string, unknown>) => Record<string, unknown>;
+}
+
+interface LinkedListNodeData {
+	id: string;
+	value: number | string;
+}
+
+/**
+ * Renderer for Linked List composite elements.
+ * Creates a horizontal chain of node rectangles connected by arrows,
+ * terminated with a null indicator.
+ *
+ * Node containers are stored in a Map for GSAP animation targeting.
+ *
+ * Rendering order (two-pass for predictable Graphics ordering):
+ * Pass 1: Node rects (Graphics) + value texts (Text)
+ * Pass 2: Arrow lines (Graphics) between adjacent nodes
+ * Pass 3: Null terminator (Graphics)
+ */
+export class LinkedListRenderer {
+	private pixi: PixiModule;
+	private nodeContainers: Record<string, Map<string, PixiContainer>> = {};
+
+	constructor(pixi: PixiModule) {
+		this.pixi = pixi;
+	}
+
+	render(element: SceneElement): PixiContainer {
+		const container = new this.pixi.Container();
+		const { style, metadata } = element;
+
+		const nodes = (metadata.nodes as unknown as LinkedListNodeData[]) ?? [];
+		const nodeWidth = (metadata.nodeWidth as number) ?? 60;
+		const nodeHeight = (metadata.nodeHeight as number) ?? 40;
+		const arrowGap = (metadata.arrowGap as number) ?? 30;
+		const highlightedNodes = (metadata.highlightedNodes as string[]) ?? [];
+		const highlightColor = (metadata.highlightColor as string) ?? '#3b82f6';
+
+		const fillColor = hexToPixiColor(style.fill);
+		const strokeColor = hexToPixiColor(style.stroke);
+		const highlightPixi = hexToPixiColor(highlightColor);
+		const cornerRadius = style.cornerRadius;
+		const stride = nodeWidth + arrowGap;
+
+		const nodeMap = new Map<string, PixiContainer>();
+
+		if (nodes.length === 0) {
+			this.nodeContainers[element.id] = nodeMap;
+			return container;
+		}
+
+		// Pass 1: Node rects and value texts
+		for (let i = 0; i < nodes.length; i++) {
+			const x = i * stride;
+			const isHighlighted = highlightedNodes.includes(nodes[i].id);
+
+			const g = new this.pixi.Graphics();
+			g.roundRect(x, 0, nodeWidth, nodeHeight, cornerRadius);
+			g.fill({ color: isHighlighted ? highlightPixi : fillColor });
+			g.stroke({ width: style.strokeWidth, color: strokeColor });
+			container.addChild(g);
+
+			const textStyle = new this.pixi.TextStyle({
+				fontSize: style.fontSize,
+				fontFamily: style.fontFamily,
+				fontWeight: String(style.fontWeight),
+				fill: hexToPixiColor(style.textColor),
+			});
+			const valueText = new this.pixi.Text({
+				text: String(nodes[i].value),
+				style: textStyle,
+			});
+			valueText.anchor.set(0.5, 0.5);
+			valueText.position.set(x + nodeWidth / 2, nodeHeight / 2);
+			container.addChild(valueText);
+
+			nodeMap.set(nodes[i].id, container);
+		}
+
+		// Pass 2: Arrow lines between adjacent nodes
+		for (let i = 0; i < nodes.length - 1; i++) {
+			const startX = i * stride + nodeWidth;
+			const endX = (i + 1) * stride;
+			const midY = nodeHeight / 2;
+
+			const arrow = new this.pixi.Graphics();
+			arrow.moveTo(startX, midY);
+			arrow.lineTo(endX, midY);
+			arrow.stroke({ width: style.strokeWidth, color: strokeColor });
+
+			// Arrowhead triangle
+			const headSize = 6;
+			arrow.poly([
+				endX,
+				midY,
+				endX - headSize,
+				midY - headSize / 2,
+				endX - headSize,
+				midY + headSize / 2,
+			]);
+			arrow.fill({ color: strokeColor });
+
+			container.addChild(arrow);
+		}
+
+		// Pass 3: Null terminator after the last node
+		const lastEndX = (nodes.length - 1) * stride + nodeWidth;
+		const midY = nodeHeight / 2;
+		const nullG = new this.pixi.Graphics();
+		nullG.moveTo(lastEndX, midY);
+		nullG.lineTo(lastEndX + arrowGap * 0.4, midY);
+		nullG.stroke({ width: style.strokeWidth, color: strokeColor });
+		// Ground symbol (two short perpendicular lines)
+		const gx = lastEndX + arrowGap * 0.5;
+		nullG.moveTo(gx, midY - 6);
+		nullG.lineTo(gx, midY + 6);
+		nullG.stroke({ width: style.strokeWidth, color: strokeColor });
+		container.addChild(nullG);
+
+		this.nodeContainers[element.id] = nodeMap;
+		return container;
+	}
+
+	getNodeContainers(elementId: string): Map<string, PixiContainer> | undefined {
+		return this.nodeContainers[elementId];
+	}
+}


### PR DESCRIPTION
## Summary
- Add `LinkedListRenderer` class that renders horizontal node chains with arrows and null terminator
- Implement 5 GSAP animation presets: `linkedListInsert`, `linkedListDelete`, `linkedListTraverse`, `linkedListReverse`, `linkedListSearch`
- Wire `linkedListNode` element type into `ElementRenderer` with accessor for animation targeting
- Two-pass rendering: node rects + value texts first, arrows + null terminator second

## Test plan
- [x] 7 renderer tests: node rects, value text, positioning, empty list, single node, highlighting, node containers
- [x] 5 preset tests: insert fade-in, delete fade-out, traverse highlight, reverse movement, search with found color
- [x] 662 total tests passing
- [x] Biome, TypeScript, Vitest all clean

Closes #22

🤖 Generated with [Claude Code](https://claude.com/claude-code)