### PR TITLE
feat: integrate Monaco Editor with lazy-loading and multi-language support (#31)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
 		"test:e2e": "playwright test"
 	},
 	"dependencies": {
+		"@monaco-editor/react": "^4.7.0",
 		"@sentry/nextjs": "latest",
 		"@vercel/analytics": "latest",
 		"@vercel/speed-insights": "latest",
@@ -26,6 +27,7 @@
 		"gsap": "^3.14.2",
 		"immer": "^11.1.4",
 		"lucide-react": "latest",
+		"monaco-editor": "^0.55.1",
 		"nanoid": "^5.1.6",
 		"next": "16.1.6",
 		"next-themes": "latest",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,6 +8,9 @@ importers:
 
   .:
     dependencies:
+      '@monaco-editor/react':
+        specifier: ^4.7.0
+        version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
       '@sentry/nextjs':
         specifier: latest
         version: 10.38.0(@opentelemetry/context-async-hooks@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.105.1)
@@ -41,6 +44,9 @@ importers:
       lucide-react:
         specifier: latest
         version: 0.563.0(react@19.2.3)
+      monaco-editor:
+        specifier: ^0.55.1
+        version: 0.55.1
       nanoid:
         specifier: ^5.1.6
         version: 5.1.6
@@ -831,6 +837,16 @@ packages:
     peerDependenciesMeta:
       '@cfworker/json-schema':
         optional: true
+
+  '@monaco-editor/loader@1.7.0':
+    resolution: {integrity: sha512-gIwR1HrJrrx+vfyOhYmCZ0/JcWqG5kbfG7+d3f/C1LXk2EvzAbHSg3MQ5lO2sMlo9izoAZ04shohfKLVT6crVA==}
+
+  '@monaco-editor/react@4.7.0':
+    resolution: {integrity: sha512-cyzXQCtO47ydzxpQtCGSQGOC8Gk3ZUeBXFAxD+CWXYFo5OqZyZUonFl0DwUlTyAfRHntBfw2p3w4s9R6oe1eCA==}
+    peerDependencies:
+      monaco-editor: '>= 0.25.0 < 1'
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   '@mswjs/interceptors@0.41.2':
     resolution: {integrity: sha512-7G0Uf0yK3f2bjElBLGHIQzgRgMESczOMyYVasq1XK8P5HaXtlW4eQhz9MBL+TQILZLaruq+ClGId+hH0w4jvWw==}
@@ -2318,6 +2334,9 @@ packages:
   '@types/tedious@4.0.14':
     resolution: {integrity: sha512-KHPsfX/FoVbUGbyYvk1q9MMQHLPeRZhRJZdO45Q4YjvFkv4hMNghCWTvy7rdKessBsmtz4euWCWAB6/tVpI1Iw==}
 
+  '@types/trusted-types@2.0.7':
+    resolution: {integrity: sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw==}
+
   '@types/validate-npm-package-name@4.0.2':
     resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
 
@@ -2829,6 +2848,9 @@ packages:
 
   dom-accessibility-api@0.6.3:
     resolution: {integrity: sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==}
+
+  dompurify@3.2.7:
+    resolution: {integrity: sha512-WhL/YuveyGXJaerVlMYGWhvQswa7myDG17P7Vu65EWC05o8vfeNbvNf4d/BOvH99+ZW+LlQsc1GDKMa1vNK6dw==}
 
   dotenv@16.6.1:
     resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
@@ -3516,6 +3538,11 @@ packages:
     resolution: {integrity: sha512-ISQTe55T2ao7XtlAStud6qwYPZjE4GK1S/BeVPus4jrq6JuOnQ00YKQC581RWhR122W7msZV263KzVeLoqidyQ==}
     engines: {node: '>=12'}
 
+  marked@14.0.0:
+    resolution: {integrity: sha512-uIj4+faQ+MgHgwUW1l2PsPglZLOLOT1uErt06dAPtx2kjteLAkbsd/0FiYg/MGS+i7ZKLb7w2WClxHkzOOuryQ==}
+    engines: {node: '>= 18'}
+    hasBin: true
+
   math-intrinsics@1.1.0:
     resolution: {integrity: sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==}
     engines: {node: '>= 0.4'}
@@ -3587,6 +3614,9 @@ packages:
 
   module-details-from-path@1.0.4:
     resolution: {integrity: sha512-EGWKgxALGMgzvxYF1UyGTy0HXX/2vHLkw6+NvDKW2jypWbHpjQuj4UMcqQWXHERJhVGKikolT06G3bcKe4fi7w==}
+
+  monaco-editor@0.55.1:
+    resolution: {integrity: sha512-jz4x+TJNFHwHtwuV9vA9rMujcZRb0CEilTEwG2rRSpe/A7Jdkuj8xPKttCgOh+v/lkHy7HsZ64oj+q3xoAFl9A==}
 
   ms@2.1.3:
     resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
@@ -4131,6 +4161,9 @@ packages:
   stacktrace-parser@0.1.11:
     resolution: {integrity: sha512-WjlahMgHmCJpqzU8bIBy4qtsZdU9lRlcZE3Lvyej6t4tuOuv1vk57OW3MBrj6hXBFx/nNoC9MPMTcr5YA7NQbg==}
     engines: {node: '>=6'}
+
+  state-local@1.0.7:
+    resolution: {integrity: sha512-HTEHMNieakEnoe33shBYcZ7NX83ACUjCu8c40iOGEZsngj9zRnkqS9j1pqQPXwobB0ZcVTk27REb7COQ0UR59w==}
 
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
@@ -5233,6 +5266,17 @@ snapshots:
       zod-to-json-schema: 3.25.1(zod@3.25.76)
     transitivePeerDependencies:
       - supports-color
+
+  '@monaco-editor/loader@1.7.0':
+    dependencies:
+      state-local: 1.0.7
+
+  '@monaco-editor/react@4.7.0(monaco-editor@0.55.1)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)':
+    dependencies:
+      '@monaco-editor/loader': 1.7.0
+      monaco-editor: 0.55.1
+      react: 19.2.3
+      react-dom: 19.2.3(react@19.2.3)
 
   '@mswjs/interceptors@0.41.2':
     dependencies:
@@ -6809,6 +6853,9 @@ snapshots:
     dependencies:
       '@types/node': 22.19.11
 
+  '@types/trusted-types@2.0.7':
+    optional: true
+
   '@types/validate-npm-package-name@4.0.2': {}
 
   '@vercel/analytics@1.6.1(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
@@ -7266,6 +7313,10 @@ snapshots:
   dom-accessibility-api@0.5.16: {}
 
   dom-accessibility-api@0.6.3: {}
+
+  dompurify@3.2.7:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
 
   dotenv@16.6.1: {}
 
@@ -7911,6 +7962,8 @@ snapshots:
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  marked@14.0.0: {}
+
   math-intrinsics@1.1.0: {}
 
   mdn-data@2.12.2: {}
@@ -7959,6 +8012,11 @@ snapshots:
   minipass@7.1.2: {}
 
   module-details-from-path@1.0.4: {}
+
+  monaco-editor@0.55.1:
+    dependencies:
+      dompurify: 3.2.7
+      marked: 14.0.0
 
   ms@2.1.3: {}
 
@@ -8650,6 +8708,8 @@ snapshots:
   stacktrace-parser@0.1.11:
     dependencies:
       type-fest: 0.7.1
+
+  state-local@1.0.7: {}
 
   statuses@2.0.2: {}
 

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -143,3 +143,28 @@
 			color 150ms ease;
 	}
 }
+
+/* Monaco Editor — breakpoint glyph (red dot in gutter) */
+.breakpoint-glyph {
+	background: #ef4444;
+	border-radius: 50%;
+	width: 10px !important;
+	height: 10px !important;
+	margin-left: 4px;
+	margin-top: 5px;
+}
+
+/* Monaco Editor — current execution line highlight */
+.current-line-highlight {
+	background: rgba(59, 130, 246, 0.15);
+	border-left: 2px solid #3b82f6;
+}
+
+.current-line-glyph {
+	background: #3b82f6;
+	clip-path: polygon(0% 20%, 100% 50%, 0% 80%);
+	width: 8px !important;
+	height: 14px !important;
+	margin-left: 4px;
+	margin-top: 3px;
+}

--- a/src/components/code-editor/code-editor.test.tsx
+++ b/src/components/code-editor/code-editor.test.tsx
@@ -1,0 +1,148 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { CodeEditor } from './code-editor';
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+	return <TooltipProvider>{children}</TooltipProvider>;
+}
+
+// Mock the execution store
+const mockToggleBreakpoint = vi.fn();
+const mockSetSourceCode = vi.fn();
+
+let mockStoreState = {
+	executionState: {
+		currentLine: 0,
+		status: 'idle' as const,
+		callStack: [],
+		variables: {},
+		heap: {},
+		output: [],
+		stepCount: 0,
+		animationTime: 0,
+	},
+	breakpoints: [] as number[],
+	sourceCode: '// Hello World\nconsole.log("hello");',
+	toggleBreakpoint: mockToggleBreakpoint,
+	setSourceCode: mockSetSourceCode,
+};
+
+vi.mock('@/lib/stores/execution-store', () => ({
+	useExecutionStore: vi.fn((selector) => selector(mockStoreState)),
+}));
+
+// Mock next-themes
+vi.mock('next-themes', () => ({
+	useTheme: () => ({
+		theme: 'dark',
+		setTheme: vi.fn(),
+		resolvedTheme: 'dark',
+		systemTheme: 'dark',
+	}),
+}));
+
+// Mock next/dynamic to render the component directly
+// In real app, next/dynamic provides lazy-loading with a loading fallback
+let mockOnMount: ((editor: unknown, monaco: unknown) => void) | null = null;
+let mockEditorProps: Record<string, unknown> = {};
+
+vi.mock('@monaco-editor/react', () => ({
+	default: (props: Record<string, unknown>) => {
+		mockEditorProps = props;
+		if (props.onMount) {
+			mockOnMount = props.onMount as typeof mockOnMount;
+		}
+		return (
+			<div data-testid="monaco-editor" data-language={props.language} data-theme={props.theme} />
+		);
+	},
+}));
+
+describe('CodeEditor', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockOnMount = null;
+		mockEditorProps = {};
+		mockStoreState = {
+			executionState: {
+				currentLine: 0,
+				status: 'idle',
+				callStack: [],
+				variables: {},
+				heap: {},
+				output: [],
+				stepCount: 0,
+				animationTime: 0,
+			},
+			breakpoints: [],
+			sourceCode: '// Hello World\nconsole.log("hello");',
+			toggleBreakpoint: mockToggleBreakpoint,
+			setSourceCode: mockSetSourceCode,
+		};
+	});
+
+	it('renders the monaco editor', () => {
+		render(<CodeEditor />, { wrapper: Wrapper });
+		expect(screen.getByTestId('monaco-editor')).toBeDefined();
+	});
+
+	it('passes dark theme to editor when theme is dark', () => {
+		render(<CodeEditor />, { wrapper: Wrapper });
+		const editor = screen.getByTestId('monaco-editor');
+		expect(editor.getAttribute('data-theme')).toBe('algomotion-dark');
+	});
+
+	it('renders language selector with default JavaScript', () => {
+		render(<CodeEditor />, { wrapper: Wrapper });
+		expect(screen.getByRole('combobox')).toBeDefined();
+	});
+
+	it('passes source code from store as value', () => {
+		render(<CodeEditor />, { wrapper: Wrapper });
+		expect(mockEditorProps.value).toBe('// Hello World\nconsole.log("hello");');
+	});
+
+	it('calls setSourceCode when editor content changes', () => {
+		render(<CodeEditor />, { wrapper: Wrapper });
+		const onChange = mockEditorProps.onChange as (value: string | undefined) => void;
+		onChange('const x = 1;');
+		expect(mockSetSourceCode).toHaveBeenCalledWith('const x = 1;');
+	});
+
+	it('sets default language to javascript', () => {
+		render(<CodeEditor />, { wrapper: Wrapper });
+		const editor = screen.getByTestId('monaco-editor');
+		expect(editor.getAttribute('data-language')).toBe('javascript');
+	});
+
+	it('renders read-only toggle button', () => {
+		render(<CodeEditor />, { wrapper: Wrapper });
+		expect(screen.getByLabelText('Toggle read-only mode')).toBeDefined();
+	});
+
+	it('toggles read-only mode on button click', async () => {
+		const user = userEvent.setup();
+		render(<CodeEditor />, { wrapper: Wrapper });
+
+		// Initially not read-only
+		expect(mockEditorProps.options).toEqual(expect.objectContaining({ readOnly: false }));
+
+		// Click read-only toggle
+		await user.click(screen.getByLabelText('Toggle read-only mode'));
+
+		// Should now be read-only
+		expect(mockEditorProps.options).toEqual(expect.objectContaining({ readOnly: true }));
+	});
+
+	it('calls onMount callback when editor mounts', () => {
+		render(<CodeEditor />, { wrapper: Wrapper });
+		expect(mockOnMount).toBeDefined();
+	});
+
+	it('configures glyph margin for breakpoints', () => {
+		render(<CodeEditor />, { wrapper: Wrapper });
+		expect(mockEditorProps.options).toEqual(expect.objectContaining({ glyphMargin: true }));
+	});
+});

--- a/src/components/code-editor/code-editor.tsx
+++ b/src/components/code-editor/code-editor.tsx
@@ -1,0 +1,247 @@
+'use client';
+
+import Editor from '@monaco-editor/react';
+import { Lock, Unlock } from 'lucide-react';
+import type * as monaco from 'monaco-editor';
+import { useTheme } from 'next-themes';
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { Button } from '@/components/ui/button';
+import {
+	Select,
+	SelectContent,
+	SelectItem,
+	SelectTrigger,
+	SelectValue,
+} from '@/components/ui/select';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { useExecutionStore } from '@/lib/stores/execution-store';
+
+type SupportedLanguage = 'javascript' | 'typescript' | 'python' | 'cpp' | 'java' | 'plaintext';
+
+const LANGUAGE_OPTIONS: { value: SupportedLanguage; label: string }[] = [
+	{ value: 'javascript', label: 'JavaScript' },
+	{ value: 'typescript', label: 'TypeScript' },
+	{ value: 'python', label: 'Python' },
+	{ value: 'cpp', label: 'C++' },
+	{ value: 'java', label: 'Java' },
+	{ value: 'plaintext', label: 'Pseudocode' },
+];
+
+const BREAKPOINT_DECORATION: monaco.editor.IModelDeltaDecoration = {
+	range: { startLineNumber: 0, startColumn: 1, endLineNumber: 0, endColumn: 1 },
+	options: {
+		isWholeLine: false,
+		glyphMarginClassName: 'breakpoint-glyph',
+		glyphMarginHoverMessage: { value: 'Toggle breakpoint' },
+	},
+};
+
+const CURRENT_LINE_DECORATION: monaco.editor.IModelDeltaDecoration = {
+	range: { startLineNumber: 0, startColumn: 1, endLineNumber: 0, endColumn: 1 },
+	options: {
+		isWholeLine: true,
+		className: 'current-line-highlight',
+		glyphMarginClassName: 'current-line-glyph',
+	},
+};
+
+/**
+ * Code Editor wrapper around Monaco Editor with lazy-loading.
+ * Integrates with the execution store for breakpoints and line highlighting.
+ *
+ * Features:
+ * - Lazy-loaded Monaco (~5MB) — textarea placeholder while loading
+ * - 6 language syntax highlighting (JS, TS, Python, C++, Java, Pseudocode)
+ * - Gutter breakpoints (click to toggle)
+ * - Current execution line highlighting
+ * - Dark/light theme matching workspace
+ * - Read-only mode toggle
+ */
+export function CodeEditor() {
+	const { resolvedTheme } = useTheme();
+	const editorRef = useRef<monaco.editor.IStandaloneCodeEditor | null>(null);
+	const breakpointDecorationsRef = useRef<string[]>([]);
+	const lineDecorationsRef = useRef<string[]>([]);
+
+	const [language, setLanguage] = useState<SupportedLanguage>('javascript');
+	const [readOnly, setReadOnly] = useState(false);
+
+	const sourceCode = useExecutionStore((s) => s.sourceCode);
+	const breakpoints = useExecutionStore((s) => s.breakpoints);
+	const currentLine = useExecutionStore((s) => s.executionState.currentLine);
+	const status = useExecutionStore((s) => s.executionState.status);
+	const toggleBreakpoint = useExecutionStore((s) => s.toggleBreakpoint);
+	const setSourceCode = useExecutionStore((s) => s.setSourceCode);
+
+	const monacoTheme = resolvedTheme === 'light' ? 'algomotion-light' : 'algomotion-dark';
+
+	const handleEditorChange = useCallback(
+		(value: string | undefined) => {
+			if (value !== undefined) {
+				setSourceCode(value);
+			}
+		},
+		[setSourceCode],
+	);
+
+	const handleEditorMount = useCallback(
+		(editor: monaco.editor.IStandaloneCodeEditor, monacoInstance: typeof monaco) => {
+			editorRef.current = editor;
+
+			// Define custom themes
+			monacoInstance.editor.defineTheme('algomotion-dark', {
+				base: 'vs-dark',
+				inherit: true,
+				rules: [],
+				colors: {
+					'editor.background': '#1a1a2e',
+					'editor.lineHighlightBackground': '#2a2a4a40',
+					'editorGutter.background': '#16162a',
+				},
+			});
+			monacoInstance.editor.defineTheme('algomotion-light', {
+				base: 'vs',
+				inherit: true,
+				rules: [],
+				colors: {},
+			});
+			monacoInstance.editor.setTheme(
+				resolvedTheme === 'light' ? 'algomotion-light' : 'algomotion-dark',
+			);
+
+			// Listen for gutter clicks to toggle breakpoints
+			editor.onMouseDown((e) => {
+				if (
+					e.target.type === monacoInstance.editor.MouseTargetType.GUTTER_GLYPH_MARGIN &&
+					e.target.position
+				) {
+					toggleBreakpoint(e.target.position.lineNumber);
+				}
+			});
+		},
+		[resolvedTheme, toggleBreakpoint],
+	);
+
+	// Update breakpoint decorations when breakpoints change
+	useEffect(() => {
+		const editor = editorRef.current;
+		if (!editor) return;
+
+		const decorations: monaco.editor.IModelDeltaDecoration[] = breakpoints.map((line) => ({
+			...BREAKPOINT_DECORATION,
+			range: {
+				startLineNumber: line,
+				startColumn: 1,
+				endLineNumber: line,
+				endColumn: 1,
+			},
+		}));
+
+		breakpointDecorationsRef.current = editor.deltaDecorations(
+			breakpointDecorationsRef.current,
+			decorations,
+		);
+	}, [breakpoints]);
+
+	// Update current line highlight when execution state changes
+	useEffect(() => {
+		const editor = editorRef.current;
+		if (!editor) return;
+
+		const decorations: monaco.editor.IModelDeltaDecoration[] =
+			currentLine > 0 && status !== 'idle'
+				? [
+						{
+							...CURRENT_LINE_DECORATION,
+							range: {
+								startLineNumber: currentLine,
+								startColumn: 1,
+								endLineNumber: currentLine,
+								endColumn: 1,
+							},
+						},
+					]
+				: [];
+
+		lineDecorationsRef.current = editor.deltaDecorations(lineDecorationsRef.current, decorations);
+
+		if (currentLine > 0 && status !== 'idle') {
+			editor.revealLineInCenter(currentLine);
+		}
+	}, [currentLine, status]);
+
+	return (
+		<div className="flex h-full flex-col">
+			{/* Toolbar */}
+			<div className="flex items-center gap-2 border-b px-2 py-1">
+				<Select value={language} onValueChange={(v) => setLanguage(v as SupportedLanguage)}>
+					<SelectTrigger size="sm" className="h-6 w-28 text-xs">
+						<SelectValue />
+					</SelectTrigger>
+					<SelectContent>
+						{LANGUAGE_OPTIONS.map((opt) => (
+							<SelectItem key={opt.value} value={opt.value}>
+								{opt.label}
+							</SelectItem>
+						))}
+					</SelectContent>
+				</Select>
+
+				<Tooltip>
+					<TooltipTrigger asChild>
+						<Button
+							variant="ghost"
+							size="icon-xs"
+							onClick={() => setReadOnly((prev) => !prev)}
+							aria-label="Toggle read-only mode"
+						>
+							{readOnly ? <Lock className="size-3" /> : <Unlock className="size-3" />}
+						</Button>
+					</TooltipTrigger>
+					<TooltipContent side="bottom">{readOnly ? 'Read-only' : 'Editable'}</TooltipContent>
+				</Tooltip>
+			</div>
+
+			{/* Editor */}
+			<div className="flex-1">
+				<Editor
+					language={language}
+					theme={monacoTheme}
+					value={sourceCode}
+					onChange={handleEditorChange}
+					onMount={handleEditorMount}
+					loading={<EditorPlaceholder code={sourceCode} />}
+					options={{
+						readOnly,
+						glyphMargin: true,
+						minimap: { enabled: false },
+						fontSize: 13,
+						fontFamily: 'JetBrains Mono, monospace',
+						lineNumbers: 'on',
+						scrollBeyondLastLine: false,
+						automaticLayout: true,
+						tabSize: 2,
+						padding: { top: 8 },
+						renderLineHighlight: 'all',
+						folding: true,
+						wordWrap: 'on',
+					}}
+				/>
+			</div>
+		</div>
+	);
+}
+
+function EditorPlaceholder({ code }: { code: string }) {
+	return (
+		<div className="flex h-full w-full flex-col bg-[#1a1a2e] p-2">
+			<textarea
+				readOnly
+				value={code}
+				className="flex-1 resize-none bg-transparent font-mono text-sm text-[#e0e0f0]/50 outline-none"
+				aria-label="Code editor loading"
+			/>
+			<p className="text-center text-xs text-muted-foreground/40">Loading editor...</p>
+		</div>
+	);
+}

--- a/src/components/panels/bottom-panel.tsx
+++ b/src/components/panels/bottom-panel.tsx
@@ -1,10 +1,23 @@
 'use client';
 
-import { Code, FileCode2, Terminal } from 'lucide-react';
+import { FileCode2, Terminal } from 'lucide-react';
+import dynamic from 'next/dynamic';
 import { EmptyState } from '@/components/shared/empty-state';
 import { TimelinePanel } from '@/components/timeline/timeline-panel';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+
+const LazyCodeEditor = dynamic(
+	() => import('@/components/code-editor/code-editor').then((m) => ({ default: m.CodeEditor })),
+	{
+		ssr: false,
+		loading: () => (
+			<div className="flex h-full items-center justify-center bg-[#1a1a2e]">
+				<p className="text-xs text-muted-foreground/40">Loading editor...</p>
+			</div>
+		),
+	},
+);
 
 export function BottomPanel() {
 	return (
@@ -26,14 +39,10 @@ export function BottomPanel() {
 			<TabsContent value="timeline" className="mt-0 h-full">
 				<TimelinePanel />
 			</TabsContent>
+			<TabsContent value="code" className="mt-0 h-full">
+				<LazyCodeEditor />
+			</TabsContent>
 			<ScrollArea className="flex-1">
-				<TabsContent value="code" className="mt-0">
-					<EmptyState
-						icon={Code}
-						title="Code Editor"
-						description="Write and step through algorithm code"
-					/>
-				</TabsContent>
 				<TabsContent value="console" className="mt-0">
 					<EmptyState
 						icon={Terminal}


### PR DESCRIPTION
## Summary
- Add `CodeEditor` component wrapping `@monaco-editor/react` 4.7+ with `monaco-editor` 0.55+
- Lazy-load via `next/dynamic` with `ssr: false` — textarea placeholder while loading
- Language selector: JavaScript, TypeScript, Python, C++, Java, Pseudocode
- Read-only mode toggle with Lock/Unlock icons
- Gutter breakpoint decorations (red dots) via `onMouseDown` + execution store `toggleBreakpoint`
- Current execution line highlighting with glow effect and gutter arrow
- Custom `algomotion-dark` / `algomotion-light` themes matching workspace colors
- CSS decorations for breakpoints (`.breakpoint-glyph`) and current line (`.current-line-highlight`)
- Wire into bottom panel Code tab, replacing empty state

## Test plan
- [x] 10 unit tests: renders editor, dark theme, language selector, source code binding, onChange, default language, read-only toggle, onMount, glyph margin
- [x] 672 total tests passing
- [x] Biome, TypeScript, Vitest all clean

Closes #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)