### PR TITLE
feat: add console output panel for code execution (#37)

### DIFF
--- a/src/components/console/console-panel.test.tsx
+++ b/src/components/console/console-panel.test.tsx
@@ -1,0 +1,97 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { ConsolePanel } from './console-panel';
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+	return <TooltipProvider>{children}</TooltipProvider>;
+}
+
+// Mock execution store
+let mockOutput: string[] = [];
+const mockClearOutput = vi.fn();
+
+vi.mock('@/lib/stores/execution-store', () => ({
+	useExecutionStore: vi.fn((selector) =>
+		selector({
+			executionState: {
+				output: mockOutput,
+				currentLine: 0,
+				status: 'idle',
+				callStack: [],
+				variables: {},
+				heap: {},
+				stepCount: 0,
+				animationTime: 0,
+			},
+			breakpoints: [],
+			sourceCode: '',
+			clearOutput: mockClearOutput,
+		}),
+	),
+}));
+
+// Mock next-themes
+vi.mock('next-themes', () => ({
+	useTheme: () => ({
+		theme: 'dark',
+		setTheme: vi.fn(),
+		resolvedTheme: 'dark',
+		systemTheme: 'dark',
+	}),
+}));
+
+describe('ConsolePanel', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockOutput = [];
+	});
+
+	it('renders the console panel', () => {
+		render(<ConsolePanel />, { wrapper: Wrapper });
+		expect(screen.getByLabelText('Console output')).toBeDefined();
+	});
+
+	it('displays output lines', () => {
+		mockOutput = ['hello world', 'value: 42'];
+		render(<ConsolePanel />, { wrapper: Wrapper });
+
+		expect(screen.getByText('hello world')).toBeDefined();
+		expect(screen.getByText('value: 42')).toBeDefined();
+	});
+
+	it('shows empty state when no output', () => {
+		mockOutput = [];
+		render(<ConsolePanel />, { wrapper: Wrapper });
+
+		expect(screen.getByText(/no output/i)).toBeDefined();
+	});
+
+	it('renders clear button', () => {
+		render(<ConsolePanel />, { wrapper: Wrapper });
+		expect(screen.getByLabelText('Clear console')).toBeDefined();
+	});
+
+	it('calls clearOutput when clear button is clicked', async () => {
+		const user = userEvent.setup();
+		mockOutput = ['some output'];
+		render(<ConsolePanel />, { wrapper: Wrapper });
+
+		await user.click(screen.getByLabelText('Clear console'));
+
+		expect(mockClearOutput).toHaveBeenCalled();
+	});
+
+	it('renders copy button', () => {
+		render(<ConsolePanel />, { wrapper: Wrapper });
+		expect(screen.getByLabelText('Copy output')).toBeDefined();
+	});
+
+	it('displays output count', () => {
+		mockOutput = ['line 1', 'line 2', 'line 3'];
+		render(<ConsolePanel />, { wrapper: Wrapper });
+
+		expect(screen.getByText('3 lines')).toBeDefined();
+	});
+});

--- a/src/components/console/console-panel.tsx
+++ b/src/components/console/console-panel.tsx
@@ -1,0 +1,83 @@
+'use client';
+
+import { ClipboardCopy, Trash2 } from 'lucide-react';
+import { useEffect, useRef } from 'react';
+import { Button } from '@/components/ui/button';
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip';
+import { useExecutionStore } from '@/lib/stores/execution-store';
+
+/**
+ * Console output panel displaying execution output.
+ * Shows console.log/print output from the execution engine,
+ * with auto-scroll, clear, and copy functionality.
+ */
+export function ConsolePanel() {
+	const output = useExecutionStore((s) => s.executionState.output);
+	const clearOutput = useExecutionStore((s) => s.clearOutput);
+	const scrollRef = useRef<HTMLDivElement>(null);
+
+	// Auto-scroll to bottom when new output arrives
+	useEffect(() => {
+		if (scrollRef.current) {
+			scrollRef.current.scrollTop = scrollRef.current.scrollHeight;
+		}
+	}, [output]);
+
+	function handleCopy() {
+		if (output.length > 0) {
+			navigator.clipboard.writeText(output.join('\n'));
+		}
+	}
+
+	return (
+		<div className="flex h-full flex-col">
+			{/* Toolbar */}
+			<div className="flex items-center justify-between border-b px-2 py-1">
+				<span className="text-xs text-muted-foreground">
+					{output.length > 0 ? `${output.length} lines` : 'Console'}
+				</span>
+				<div className="flex items-center gap-1">
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button variant="ghost" size="icon-xs" onClick={handleCopy} aria-label="Copy output">
+								<ClipboardCopy className="size-3" />
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent side="bottom">Copy to clipboard</TooltipContent>
+					</Tooltip>
+					<Tooltip>
+						<TooltipTrigger asChild>
+							<Button
+								variant="ghost"
+								size="icon-xs"
+								onClick={clearOutput}
+								aria-label="Clear console"
+							>
+								<Trash2 className="size-3" />
+							</Button>
+						</TooltipTrigger>
+						<TooltipContent side="bottom">Clear console</TooltipContent>
+					</Tooltip>
+				</div>
+			</div>
+
+			{/* Output area */}
+			<div
+				ref={scrollRef}
+				className="flex-1 overflow-y-auto p-2 font-mono text-xs"
+				role="log"
+				aria-label="Console output"
+			>
+				{output.length === 0 ? (
+					<p className="text-muted-foreground/40">No output yet. Run code to see results.</p>
+				) : (
+					output.map((line, i) => (
+						<div key={`${i}-${line.slice(0, 20)}`} className="py-0.5 text-foreground/80">
+							{line}
+						</div>
+					))
+				)}
+			</div>
+		</div>
+	);
+}

--- a/src/components/panels/bottom-panel.tsx
+++ b/src/components/panels/bottom-panel.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FileCode2, Terminal } from 'lucide-react';
+import { FileCode2 } from 'lucide-react';
 import dynamic from 'next/dynamic';
 import { EmptyState } from '@/components/shared/empty-state';
 import { TimelinePanel } from '@/components/timeline/timeline-panel';
@@ -14,6 +14,18 @@ const LazyCodeEditor = dynamic(
 		loading: () => (
 			<div className="flex h-full items-center justify-center bg-[#1a1a2e]">
 				<p className="text-xs text-muted-foreground/40">Loading editor...</p>
+			</div>
+		),
+	},
+);
+
+const LazyConsolePanel = dynamic(
+	() => import('@/components/console/console-panel').then((m) => ({ default: m.ConsolePanel })),
+	{
+		ssr: false,
+		loading: () => (
+			<div className="flex h-full items-center justify-center">
+				<p className="text-xs text-muted-foreground/40">Loading console...</p>
 			</div>
 		),
 	},
@@ -42,14 +54,10 @@ export function BottomPanel() {
 			<TabsContent value="code" className="mt-0 h-full">
 				<LazyCodeEditor />
 			</TabsContent>
+			<TabsContent value="console" className="mt-0 h-full">
+				<LazyConsolePanel />
+			</TabsContent>
 			<ScrollArea className="flex-1">
-				<TabsContent value="console" className="mt-0">
-					<EmptyState
-						icon={Terminal}
-						title="Console"
-						description="Code execution output will appear here"
-					/>
-				</TabsContent>
 				<TabsContent value="dsl" className="mt-0">
 					<EmptyState
 						icon={FileCode2}


### PR DESCRIPTION
## Summary
- Built `ConsolePanel` component with auto-scroll, clear output, and copy-to-clipboard functionality
- Wired into `bottom-panel.tsx` via `next/dynamic` with `ssr: false` for lazy loading
- Connects to execution store for real-time output display with line count indicator
- Added `role="log"` for proper ARIA semantics on the output container

## Test plan
- [x] 7 unit tests covering: render, output lines, empty state, clear button, copy button, output count, clear callback
- [x] All 715 tests pass (`pnpm vitest run`)
- [x] Biome lint + format clean
- [x] TypeScript strict mode passes

Closes #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)