### PR TITLE
feat: implement Queue composite with enqueue/dequeue animations (#24)

### DIFF
--- a/src/lib/gsap/presets/queue-presets.test.ts
+++ b/src/lib/gsap/presets/queue-presets.test.ts
@@ -1,0 +1,85 @@
+import gsap from 'gsap';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { queueDequeue, queueEmpty, queueEnqueue, queueFull } from './queue-presets';
+
+interface AnimatableCell {
+	position: { x: number; y: number };
+	alpha: number;
+	scale: { x: number; y: number };
+	_fillColor: number;
+}
+
+function makeCell(x: number): AnimatableCell {
+	return {
+		position: { x, y: 0 },
+		alpha: 1,
+		scale: { x: 1, y: 1 },
+		_fillColor: 0x2a2a4a,
+	};
+}
+
+describe('Queue Animation Presets', () => {
+	beforeEach(() => {
+		gsap.ticker.lagSmoothing(0);
+	});
+
+	describe('queueEnqueue', () => {
+		it('returns a GSAP timeline', () => {
+			const newCell = makeCell(200);
+			newCell.alpha = 0;
+			newCell.scale = { x: 0, y: 0 };
+			const tl = queueEnqueue(newCell);
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+		});
+
+		it('animates new cell to visible', () => {
+			const newCell = makeCell(200);
+			newCell.alpha = 0;
+			newCell.scale = { x: 0, y: 0 };
+			const tl = queueEnqueue(newCell);
+			tl.progress(1);
+			expect(newCell.alpha).toBe(1);
+			expect(newCell.scale.x).toBeCloseTo(1, 1);
+		});
+	});
+
+	describe('queueDequeue', () => {
+		it('returns a GSAP timeline', () => {
+			const cell = makeCell(0);
+			const tl = queueDequeue(cell);
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+		});
+
+		it('animates cell to invisible and shifts left', () => {
+			const cell = makeCell(0);
+			const tl = queueDequeue(cell);
+			tl.progress(1);
+			expect(cell.alpha).toBe(0);
+		});
+	});
+
+	describe('queueFull', () => {
+		it('returns a GSAP timeline', () => {
+			const cells = [makeCell(0), makeCell(52)];
+			const tl = queueFull(cells, 0xff4444);
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+		});
+
+		it('flashes all cells with error color and reverts', () => {
+			const cells = [makeCell(0), makeCell(52)];
+			const originalColors = cells.map((c) => c._fillColor);
+			const tl = queueFull(cells, 0xff4444);
+			tl.progress(1);
+			for (let i = 0; i < cells.length; i++) {
+				expect(cells[i]._fillColor).toBe(originalColors[i]);
+			}
+		});
+	});
+
+	describe('queueEmpty', () => {
+		it('returns a GSAP timeline for empty queue indicator', () => {
+			const tl = queueEmpty();
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+		});
+	});
+});

--- a/src/lib/gsap/presets/queue-presets.ts
+++ b/src/lib/gsap/presets/queue-presets.ts
@@ -1,0 +1,61 @@
+import gsap from 'gsap';
+
+interface AnimatableCell {
+	position: { x: number; y: number };
+	alpha: number;
+	scale: { x: number; y: number };
+	_fillColor: number;
+}
+
+/**
+ * Enqueue animation — fades in and scales up a new cell at the rear.
+ * The cell should start with alpha: 0 and scale: { x: 0, y: 0 }.
+ */
+export function queueEnqueue(newCell: AnimatableCell): gsap.core.Timeline {
+	const tl = gsap.timeline();
+
+	tl.to(newCell, { alpha: 1, duration: 0.2, ease: 'power1.out' }, 0);
+	tl.to(newCell.scale, { x: 1, y: 1, duration: 0.2, ease: 'back.out' }, 0);
+
+	return tl;
+}
+
+/**
+ * Dequeue animation — fades out and slides the front cell to the left.
+ */
+export function queueDequeue(cell: AnimatableCell): gsap.core.Timeline {
+	const tl = gsap.timeline();
+
+	tl.to(cell, { alpha: 0, duration: 0.2, ease: 'power1.in' }, 0);
+	tl.to(cell.position, { x: cell.position.x - 40, duration: 0.2, ease: 'power1.in' }, 0);
+	tl.to(cell.scale, { x: 0.8, y: 0.8, duration: 0.2, ease: 'power1.in' }, 0);
+
+	return tl;
+}
+
+/**
+ * Full queue error animation — flashes all cells with an error color, then reverts.
+ */
+export function queueFull(cells: AnimatableCell[], errorColor: number): gsap.core.Timeline {
+	const tl = gsap.timeline();
+	const originalColors = cells.map((c) => c._fillColor);
+
+	for (const cell of cells) {
+		tl.to(cell, { _fillColor: errorColor, duration: 0.15 }, 0);
+	}
+
+	for (let i = 0; i < cells.length; i++) {
+		tl.to(cells[i], { _fillColor: originalColors[i], duration: 0.15 }, 0.3);
+	}
+
+	return tl;
+}
+
+/**
+ * Empty queue indicator animation — a brief duration to mark the empty state.
+ */
+export function queueEmpty(): gsap.core.Timeline {
+	const tl = gsap.timeline();
+	tl.to({}, { duration: 0.3 });
+	return tl;
+}

--- a/src/lib/pixi/renderers/element-renderer.ts
+++ b/src/lib/pixi/renderers/element-renderer.ts
@@ -2,6 +2,7 @@ import type { ArrowShape, SceneElement } from '@/types';
 import { ArrayRenderer } from './array-renderer';
 import { GraphRenderer } from './graph-renderer';
 import { LinkedListRenderer } from './linked-list-renderer';
+import { QueueRenderer } from './queue-renderer';
 import { calculateArrowheadPoints, hexToPixiColor } from './shared';
 import { StackRenderer } from './stack-renderer';
 import { TreeRenderer } from './tree-renderer';
@@ -78,6 +79,7 @@ export class ElementRenderer {
 	private graphRenderer: GraphRenderer;
 	private linkedListRenderer: LinkedListRenderer;
 	private stackRenderer: StackRenderer;
+	private queueRenderer: QueueRenderer;
 
 	constructor(pixi: PixiModule) {
 		this.pixi = pixi;
@@ -86,6 +88,7 @@ export class ElementRenderer {
 		this.graphRenderer = new GraphRenderer(pixi as never);
 		this.linkedListRenderer = new LinkedListRenderer(pixi as never);
 		this.stackRenderer = new StackRenderer(pixi as never);
+		this.queueRenderer = new QueueRenderer(pixi as never);
 	}
 
 	/**
@@ -135,6 +138,13 @@ export class ElementRenderer {
 	 */
 	getStackFrameContainers(elementId: string): unknown[] | undefined {
 		return this.stackRenderer.getFrameContainers(elementId);
+	}
+
+	/**
+	 * Get queue cell containers for animation targeting.
+	 */
+	getQueueCellContainers(elementId: string): unknown[] | undefined {
+		return this.queueRenderer.getCellContainers(elementId);
 	}
 
 	/**
@@ -195,6 +205,11 @@ export class ElementRenderer {
 			case 'stackFrame': {
 				const stackContainer = this.stackRenderer.render(element);
 				container.addChild(stackContainer);
+				break;
+			}
+			case 'queueCell': {
+				const queueContainer = this.queueRenderer.render(element);
+				container.addChild(queueContainer);
 				break;
 			}
 			default:
@@ -258,6 +273,11 @@ export class ElementRenderer {
 			case 'stackFrame': {
 				const stackContainer = this.stackRenderer.render(element);
 				container.addChild(stackContainer);
+				break;
+			}
+			case 'queueCell': {
+				const queueContainer = this.queueRenderer.render(element);
+				container.addChild(queueContainer);
 				break;
 			}
 			default:

--- a/src/lib/pixi/renderers/queue-renderer.test.ts
+++ b/src/lib/pixi/renderers/queue-renderer.test.ts
@@ -1,0 +1,195 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { SceneElement } from '@/types';
+import { QueueRenderer } from './queue-renderer';
+import { DEFAULT_ELEMENT_STYLE } from './shared';
+
+function createMockPixi() {
+	function MockContainer(this: Record<string, unknown>) {
+		const children: unknown[] = [];
+		this.addChild = vi.fn((...args: unknown[]) => children.push(...args));
+		this.removeChildren = vi.fn();
+		this.destroy = vi.fn();
+		this.position = { set: vi.fn(), x: 0, y: 0 };
+		this.alpha = 1;
+		this.angle = 0;
+		this.visible = true;
+		this.label = '';
+		this.cullable = false;
+		this.children = children;
+	}
+
+	function MockGraphics(this: Record<string, unknown>) {
+		this.clear = vi.fn().mockReturnThis();
+		this.rect = vi.fn().mockReturnThis();
+		this.roundRect = vi.fn().mockReturnThis();
+		this.circle = vi.fn().mockReturnThis();
+		this.fill = vi.fn().mockReturnThis();
+		this.stroke = vi.fn().mockReturnThis();
+		this.moveTo = vi.fn().mockReturnThis();
+		this.lineTo = vi.fn().mockReturnThis();
+		this.bezierCurveTo = vi.fn().mockReturnThis();
+		this.poly = vi.fn().mockReturnThis();
+		this.closePath = vi.fn().mockReturnThis();
+		this.destroy = vi.fn();
+	}
+
+	function MockText(this: Record<string, unknown>, opts: { text: string; style: unknown }) {
+		this.text = opts.text;
+		this.style = opts.style;
+		this.anchor = { set: vi.fn() };
+		this.position = { set: vi.fn() };
+		this.visible = true;
+		this.destroy = vi.fn();
+	}
+
+	function MockTextStyle(_opts: Record<string, unknown>) {
+		return { ..._opts };
+	}
+
+	return {
+		Container: vi.fn().mockImplementation(MockContainer),
+		Graphics: vi.fn().mockImplementation(MockGraphics),
+		Text: vi.fn().mockImplementation(MockText),
+		TextStyle: vi.fn().mockImplementation(MockTextStyle),
+	};
+}
+
+function makeQueueElement(overrides?: Partial<SceneElement>): SceneElement {
+	return {
+		id: 'queue-1',
+		type: 'queueCell',
+		position: { x: 50, y: 100 },
+		size: { width: 400, height: 60 },
+		rotation: 0,
+		opacity: 1,
+		visible: true,
+		locked: false,
+		label: '',
+		style: {
+			...DEFAULT_ELEMENT_STYLE,
+			fill: '#2a2a4a',
+			stroke: '#6366f1',
+			cornerRadius: 4,
+			fontSize: 14,
+			fontFamily: 'JetBrains Mono, monospace',
+			fontWeight: 600,
+			textColor: '#e0e0f0',
+		},
+		metadata: {
+			values: [10, 20, 30],
+			cellSize: 48,
+			gap: 4,
+			front: 0,
+			rear: 2,
+			highlightedIndex: -1,
+			highlightColor: '#3b82f6',
+		},
+		...overrides,
+	};
+}
+
+describe('QueueRenderer', () => {
+	let pixi: ReturnType<typeof createMockPixi>;
+	let renderer: QueueRenderer;
+
+	beforeEach(() => {
+		pixi = createMockPixi();
+		renderer = new QueueRenderer(pixi as never);
+	});
+
+	it('renders cell rectangles with value text', () => {
+		const element = makeQueueElement();
+		const container = renderer.render(element);
+
+		expect(container.addChild).toHaveBeenCalled();
+		// 3 cells: each gets Graphics (rect) + Text (value) = 6
+		// 2 marker texts (FRONT + REAR) = 2
+		// Total: 8
+		const addChildCalls = (container.addChild as ReturnType<typeof vi.fn>).mock.calls;
+		expect(addChildCalls.length).toBe(8);
+	});
+
+	it('renders value text for each cell', () => {
+		const element = makeQueueElement();
+		renderer.render(element);
+
+		const textCalls = (pixi.Text as ReturnType<typeof vi.fn>).mock.calls;
+		// 3 value texts + 2 markers (FRONT, REAR) = 5
+		expect(textCalls.length).toBe(5);
+		expect(textCalls[0][0].text).toBe('10');
+		expect(textCalls[1][0].text).toBe('20');
+		expect(textCalls[2][0].text).toBe('30');
+	});
+
+	it('positions cells horizontally', () => {
+		const element = makeQueueElement();
+		renderer.render(element);
+
+		const graphicsResults = (pixi.Graphics as ReturnType<typeof vi.fn>).mock.results;
+		const stride = 48 + 4; // cellSize + gap
+		for (let i = 0; i < 3; i++) {
+			const g = graphicsResults[i].value;
+			expect(g.roundRect).toHaveBeenCalledWith(i * stride, 0, 48, 48, 4);
+		}
+	});
+
+	it('handles empty queue', () => {
+		const element = makeQueueElement({
+			metadata: {
+				values: [],
+				cellSize: 48,
+				gap: 4,
+				front: 0,
+				rear: -1,
+				highlightedIndex: -1,
+				highlightColor: '#3b82f6',
+			},
+		});
+		const container = renderer.render(element);
+		// Empty queue: only "EMPTY" text
+		const addChildCalls = (container.addChild as ReturnType<typeof vi.fn>).mock.calls;
+		expect(addChildCalls.length).toBe(1);
+	});
+
+	it('renders FRONT and REAR marker texts', () => {
+		const element = makeQueueElement();
+		renderer.render(element);
+
+		const textCalls = (pixi.Text as ReturnType<typeof vi.fn>).mock.calls;
+		const markers = textCalls.filter(
+			(c: unknown[]) =>
+				(c[0] as { text: string }).text === 'FRONT' || (c[0] as { text: string }).text === 'REAR',
+		);
+		expect(markers.length).toBe(2);
+	});
+
+	it('applies highlight fill color to highlighted cell', () => {
+		const element = makeQueueElement({
+			metadata: {
+				values: [10, 20, 30],
+				cellSize: 48,
+				gap: 4,
+				front: 0,
+				rear: 2,
+				highlightedIndex: 1,
+				highlightColor: '#3b82f6',
+			},
+		});
+		renderer.render(element);
+
+		const graphicsResults = (pixi.Graphics as ReturnType<typeof vi.fn>).mock.results;
+		// Cell 0: normal
+		expect(graphicsResults[0].value.fill).toHaveBeenCalledWith({ color: 0x2a2a4a });
+		// Cell 1: highlighted
+		expect(graphicsResults[1].value.fill).toHaveBeenCalledWith({ color: 0x3b82f6 });
+	});
+
+	it('returns cell containers for animation targeting', () => {
+		const element = makeQueueElement();
+		renderer.render(element);
+
+		const cellContainers = renderer.getCellContainers('queue-1');
+		expect(cellContainers).toBeDefined();
+		expect(cellContainers?.length).toBe(3);
+	});
+});

--- a/src/lib/pixi/renderers/queue-renderer.ts
+++ b/src/lib/pixi/renderers/queue-renderer.ts
@@ -1,0 +1,165 @@
+import type { SceneElement } from '@/types';
+import { hexToPixiColor } from './shared';
+
+interface PixiContainer {
+	addChild(...children: unknown[]): void;
+	removeChildren(): void;
+	destroy(options?: { children: boolean }): void;
+	position: { set(x: number, y: number): void; x: number; y: number };
+	alpha: number;
+	angle: number;
+	visible: boolean;
+	label: string;
+	cullable: boolean;
+	children: unknown[];
+}
+
+interface PixiGraphics {
+	clear(): PixiGraphics;
+	rect(x: number, y: number, w: number, h: number): PixiGraphics;
+	roundRect(x: number, y: number, w: number, h: number, r: number): PixiGraphics;
+	circle(x: number, y: number, r: number): PixiGraphics;
+	fill(opts: { color: number; alpha?: number } | number): PixiGraphics;
+	stroke(opts: { width: number; color: number; alpha?: number }): PixiGraphics;
+	moveTo(x: number, y: number): PixiGraphics;
+	lineTo(x: number, y: number): PixiGraphics;
+	bezierCurveTo(
+		cp1x: number,
+		cp1y: number,
+		cp2x: number,
+		cp2y: number,
+		x: number,
+		y: number,
+	): PixiGraphics;
+	poly(points: number[]): PixiGraphics;
+	closePath(): PixiGraphics;
+	destroy(): void;
+}
+
+interface PixiText {
+	text: string;
+	style: Record<string, unknown>;
+	anchor: { set(x: number, y: number): void };
+	position: { set(x: number, y: number): void };
+	visible: boolean;
+	destroy(): void;
+}
+
+interface PixiModule {
+	Container: new () => PixiContainer;
+	Graphics: new () => PixiGraphics;
+	Text: new (opts: { text: string; style: unknown }) => PixiText;
+	TextStyle: new (opts: Record<string, unknown>) => Record<string, unknown>;
+}
+
+/**
+ * Renderer for Queue composite elements.
+ * Creates a horizontal FIFO structure with cells and front/rear markers.
+ *
+ * Rendering order:
+ * Pass 1: Cell rects (Graphics) + value texts (Text)
+ * Pass 2: FRONT and REAR marker labels
+ *
+ * Cell containers are stored for GSAP animation targeting.
+ */
+export class QueueRenderer {
+	private pixi: PixiModule;
+	private cellContainers: Record<string, PixiContainer[]> = {};
+
+	constructor(pixi: PixiModule) {
+		this.pixi = pixi;
+	}
+
+	render(element: SceneElement): PixiContainer {
+		const container = new this.pixi.Container();
+		const { style, metadata } = element;
+
+		const values = (metadata.values as (number | string)[]) ?? [];
+		const cellSize = (metadata.cellSize as number) ?? 48;
+		const gap = (metadata.gap as number) ?? 4;
+		const front = (metadata.front as number) ?? 0;
+		const rear = (metadata.rear as number) ?? values.length - 1;
+		const highlightedIndex = (metadata.highlightedIndex as number) ?? -1;
+		const highlightColor = (metadata.highlightColor as string) ?? '#3b82f6';
+
+		const fillColor = hexToPixiColor(style.fill);
+		const strokeColor = hexToPixiColor(style.stroke);
+		const highlightPixi = hexToPixiColor(highlightColor);
+		const cornerRadius = style.cornerRadius;
+		const stride = cellSize + gap;
+
+		const cells: PixiContainer[] = [];
+
+		if (values.length === 0) {
+			const emptyStyle = new this.pixi.TextStyle({
+				fontSize: style.fontSize - 2,
+				fontFamily: style.fontFamily,
+				fontWeight: '400',
+				fill: hexToPixiColor(style.textColor),
+			});
+			const emptyText = new this.pixi.Text({ text: 'EMPTY', style: emptyStyle });
+			emptyText.anchor.set(0.5, 0.5);
+			emptyText.position.set(cellSize / 2, cellSize / 2);
+			container.addChild(emptyText);
+
+			this.cellContainers[element.id] = cells;
+			return container;
+		}
+
+		// Pass 1: Cell rects and value texts
+		for (let i = 0; i < values.length; i++) {
+			const x = i * stride;
+			const isHighlighted = i === highlightedIndex;
+
+			const g = new this.pixi.Graphics();
+			g.roundRect(x, 0, cellSize, cellSize, cornerRadius);
+			g.fill({ color: isHighlighted ? highlightPixi : fillColor });
+			g.stroke({ width: style.strokeWidth, color: strokeColor });
+			container.addChild(g);
+
+			const textStyle = new this.pixi.TextStyle({
+				fontSize: style.fontSize,
+				fontFamily: style.fontFamily,
+				fontWeight: String(style.fontWeight),
+				fill: hexToPixiColor(style.textColor),
+			});
+			const valueText = new this.pixi.Text({
+				text: String(values[i]),
+				style: textStyle,
+			});
+			valueText.anchor.set(0.5, 0.5);
+			valueText.position.set(x + cellSize / 2, cellSize / 2);
+			container.addChild(valueText);
+
+			cells.push(container);
+		}
+
+		// Pass 2: FRONT and REAR markers below the cells
+		const markerStyle = new this.pixi.TextStyle({
+			fontSize: Math.max(10, style.fontSize - 4),
+			fontFamily: style.fontFamily,
+			fontWeight: '600',
+			fill: hexToPixiColor(highlightColor),
+		});
+
+		const frontText = new this.pixi.Text({ text: 'FRONT', style: markerStyle });
+		frontText.anchor.set(0.5, 0);
+		frontText.position.set(front * stride + cellSize / 2, cellSize + 4);
+		container.addChild(frontText);
+
+		const rearText = new this.pixi.Text({ text: 'REAR', style: markerStyle });
+		rearText.anchor.set(0.5, 0);
+		rearText.position.set(rear * stride + cellSize / 2, cellSize + 4);
+		container.addChild(rearText);
+
+		this.cellContainers[element.id] = cells;
+		return container;
+	}
+
+	/**
+	 * Get cell containers for animation targeting.
+	 */
+	getCellContainers(elementId: string): PixiContainer[] | undefined {
+		return this.cellContainers[elementId];
+	}
+}

--- a/src/types/elements.test.ts
+++ b/src/types/elements.test.ts
@@ -53,8 +53,8 @@ describe('element category constants', () => {
 		expect(PRIMITIVE_TYPES).toContain('image');
 	});
 
-	it('has 8 data structure types', () => {
-		expect(DATA_STRUCTURE_TYPES).toHaveLength(8);
+	it('has 9 data structure types', () => {
+		expect(DATA_STRUCTURE_TYPES).toHaveLength(9);
 		expect(DATA_STRUCTURE_TYPES).toContain('arrayCell');
 		expect(DATA_STRUCTURE_TYPES).toContain('treeNode');
 		expect(DATA_STRUCTURE_TYPES).toContain('linkedListNode');
@@ -80,7 +80,7 @@ describe('element category constants', () => {
 		expect(ANNOTATION_TYPES).toContain('codeSnippet');
 	});
 
-	it('covers all 34 element types across categories', () => {
+	it('covers all 35 element types across categories', () => {
 		const allTypes = [
 			...PRIMITIVE_TYPES,
 			...DATA_STRUCTURE_TYPES,
@@ -88,9 +88,9 @@ describe('element category constants', () => {
 			...MATH_TYPES,
 			...ANNOTATION_TYPES,
 		];
-		expect(allTypes).toHaveLength(34);
+		expect(allTypes).toHaveLength(35);
 		// No duplicates
-		expect(new Set(allTypes).size).toBe(34);
+		expect(new Set(allTypes).size).toBe(35);
 	});
 });
 

--- a/src/types/elements.ts
+++ b/src/types/elements.ts
@@ -24,6 +24,7 @@ export type ElementType =
 	| 'treeNode'
 	| 'graphNode'
 	| 'linkedListNode'
+	| 'queueCell'
 	| 'hashBucket'
 	// Architecture
 	| 'register'
@@ -105,6 +106,7 @@ export const DATA_STRUCTURE_TYPES = [
 	'treeNode',
 	'graphNode',
 	'linkedListNode',
+	'queueCell',
 	'hashBucket',
 ] as const satisfies readonly ElementType[];
 
@@ -164,6 +166,7 @@ const NODE_TYPES: ReadonlySet<string> = new Set([
 	'treeNode',
 	'graphNode',
 	'linkedListNode',
+	'queueCell',
 	'hashBucket',
 	'register',
 	'aluUnit',


### PR DESCRIPTION
## Summary
- Built `QueueRenderer` for horizontal FIFO visualization with cell rects, value text, and FRONT/REAR marker labels
- Implemented 4 GSAP animation presets: `queueEnqueue`, `queueDequeue`, `queueFull`, `queueEmpty`
- Added `queueCell` to `ElementType` union and `DATA_STRUCTURE_TYPES` array
- Wired `QueueRenderer` into `ElementRenderer` with `queueCell` type case and `getQueueCellContainers()` accessor

## Test plan
- [x] 7 renderer tests: cell rects, value text, horizontal positioning, empty queue, FRONT/REAR markers, highlight, cell containers
- [x] 7 preset tests: enqueue/dequeue timeline creation, enqueue visibility, dequeue fade-out, full flash+revert, empty timeline
- [x] Updated element type tests (DATA_STRUCTURE_TYPES length 8→9, total types 34→35)
- [x] All 746 tests pass (`pnpm vitest run`)
- [x] Biome lint + format clean
- [x] TypeScript strict mode passes

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)