### PR TITLE
feat: implement semantic color system with theme support (#30)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -59,6 +59,7 @@
 	--color-highlight: #ffd700;
 	--color-path: #06b6d4;
 	--color-pivot: #ec4899;
+	--color-error: #ef4444;
 }
 
 :root {

--- a/src/lib/colors.test.ts
+++ b/src/lib/colors.test.ts
@@ -2,9 +2,12 @@ import { describe, expect, it } from 'vitest';
 import {
 	blendColors,
 	getSemanticColorNumber,
+	getThemeColors,
 	hexToNumber,
 	numberToHex,
+	resolveSemanticColors,
 	SEMANTIC_COLOR_KEYS,
+	STATE_INDICATORS,
 	semanticColors,
 } from './colors';
 
@@ -109,5 +112,77 @@ describe('blendColors', () => {
 
 	it('clamps ratio above 1', () => {
 		expect(blendColors('#ff0000', '#0000ff', 2)).toBe('#0000ff');
+	});
+});
+
+describe('getThemeColors', () => {
+	it('returns dark theme colors by default', () => {
+		const colors = getThemeColors('dark');
+		expect(colors.active).toBe(semanticColors.active);
+		expect(colors.sorted).toBe(semanticColors.sorted);
+	});
+
+	it('returns light theme colors with adjusted values', () => {
+		const colors = getThemeColors('light');
+		// Light theme should have all 10 keys
+		expect(Object.keys(colors)).toHaveLength(10);
+		// Light theme adjusts unvisited for darker background contrast
+		expect(colors.unvisited).not.toBe(semanticColors.unvisited);
+	});
+
+	it('returns all 10 semantic color keys for both themes', () => {
+		const dark = getThemeColors('dark');
+		const light = getThemeColors('light');
+		for (const key of SEMANTIC_COLOR_KEYS) {
+			expect(dark[key]).toBeDefined();
+			expect(light[key]).toBeDefined();
+		}
+	});
+});
+
+describe('resolveSemanticColors', () => {
+	it('returns default colors when no overrides provided', () => {
+		const resolved = resolveSemanticColors('dark');
+		expect(resolved.active).toBe(semanticColors.active);
+	});
+
+	it('merges user overrides with defaults', () => {
+		const resolved = resolveSemanticColors('dark', { active: '#ff0000' });
+		expect(resolved.active).toBe('#ff0000');
+		expect(resolved.sorted).toBe(semanticColors.sorted);
+	});
+
+	it('preserves all keys even when overriding some', () => {
+		const resolved = resolveSemanticColors('dark', { error: '#cc0000' });
+		expect(Object.keys(resolved)).toHaveLength(10);
+		expect(resolved.error).toBe('#cc0000');
+	});
+});
+
+describe('STATE_INDICATORS', () => {
+	it('defines multi-signal indicators for key states', () => {
+		expect(STATE_INDICATORS.sorted).toBeDefined();
+		expect(STATE_INDICATORS.sorted.colorKey).toBe('sorted');
+		expect(STATE_INDICATORS.sorted.icon).toBe('check');
+
+		expect(STATE_INDICATORS.error).toBeDefined();
+		expect(STATE_INDICATORS.error.colorKey).toBe('error');
+		expect(STATE_INDICATORS.error.icon).toBe('x');
+	});
+
+	it('includes indicator for active state with pulse effect', () => {
+		expect(STATE_INDICATORS.active.colorKey).toBe('active');
+		expect(STATE_INDICATORS.active.effect).toBe('pulse');
+	});
+
+	it('includes indicator for comparing state', () => {
+		expect(STATE_INDICATORS.comparing.colorKey).toBe('comparing');
+		expect(STATE_INDICATORS.comparing.icon).toBe('arrows');
+	});
+
+	it('all indicators have a colorKey', () => {
+		for (const indicator of Object.values(STATE_INDICATORS)) {
+			expect(indicator.colorKey).toBeDefined();
+		}
 	});
 });

--- a/src/lib/colors.ts
+++ b/src/lib/colors.ts
@@ -54,6 +54,71 @@ export function getSemanticColorNumber(key: SemanticColorKey): number {
 	return hexToNumber(semanticColors[key]);
 }
 
+// ── Theme-Aware Colors ──
+
+/**
+ * Light mode color adjustments.
+ * Most semantic colors are designed for dark canvas backgrounds.
+ * For light mode UI elements, some colors need adjustment for contrast.
+ */
+const lightThemeOverrides: Partial<Record<SemanticColorKey, string>> = {
+	unvisited: '#9ca3af', // gray-400 — darker for light backgrounds
+	visited: '#4b5563', // gray-600 — darker for light backgrounds
+};
+
+/**
+ * Get the semantic color palette for a given theme.
+ * Dark theme uses the default palette; light theme applies contrast adjustments.
+ */
+export function getThemeColors(theme: 'dark' | 'light'): Record<SemanticColorKey, string> {
+	if (theme === 'light') {
+		return { ...semanticColors, ...lightThemeOverrides };
+	}
+	return { ...semanticColors };
+}
+
+/**
+ * Resolve semantic colors with optional user overrides.
+ * Merges theme defaults with any user-provided color overrides.
+ */
+export function resolveSemanticColors(
+	theme: 'dark' | 'light',
+	overrides?: Partial<Record<SemanticColorKey, string>>,
+): Record<SemanticColorKey, string> {
+	const base = getThemeColors(theme);
+	if (!overrides) return base;
+	return { ...base, ...overrides };
+}
+
+// ── Multi-Signal State Indicators ──
+
+/**
+ * State indicator definition.
+ * Per accessibility guidelines (Section 15.5), color must never be the
+ * sole indicator of state — each state also has an icon and/or effect.
+ */
+export interface StateIndicator {
+	colorKey: SemanticColorKey;
+	icon?: 'check' | 'x' | 'arrows' | 'arrow-right' | 'eye' | 'star' | 'dot';
+	effect?: 'pulse' | 'bounce' | 'shake';
+}
+
+/**
+ * Multi-signal indicator mapping for key animation states.
+ * Each state has a color AND at least one other visual cue (icon or effect).
+ */
+export const STATE_INDICATORS: Record<string, StateIndicator> = {
+	sorted: { colorKey: 'sorted', icon: 'check' },
+	error: { colorKey: 'error', icon: 'x', effect: 'shake' },
+	active: { colorKey: 'active', effect: 'pulse' },
+	comparing: { colorKey: 'comparing', icon: 'arrows' },
+	swapping: { colorKey: 'swapping', effect: 'bounce' },
+	visited: { colorKey: 'visited', icon: 'dot' },
+	path: { colorKey: 'path', icon: 'arrow-right' },
+	pivot: { colorKey: 'pivot', icon: 'star' },
+	highlight: { colorKey: 'highlight', effect: 'pulse' },
+};
+
 /**
  * Blend two hex colors by a ratio (0 = first color, 1 = second color).
  */


### PR DESCRIPTION
## Summary
- Added `getThemeColors()` for dark/light theme-aware color palettes with adjusted contrast
- Added `resolveSemanticColors()` for merging user overrides with theme defaults
- Added `STATE_INDICATORS` mapping with multi-signal indicators (color + icon/effect) per WCAG accessibility
- Added missing `--color-error` CSS variable in globals.css
- Exported `StateIndicator` interface for use by renderers and animation presets

## Test plan
- [x] 10 new tests: getThemeColors (dark default, light variants, all keys), resolveSemanticColors (no overrides, with overrides, key preservation), STATE_INDICATORS (sorted, error, active, comparing, all have colorKey)
- [x] All 756 tests pass (`pnpm vitest run`)
- [x] Biome lint + format clean
- [x] TypeScript strict mode passes

Closes #30

🤖 Generated with [Claude Code](https://claude.com/claude-code)