### PR TITLE
feat: build Properties Inspector panel (#28)

### DIFF
--- a/src/components/panels/properties-inspector.test.tsx
+++ b/src/components/panels/properties-inspector.test.tsx
@@ -1,0 +1,170 @@
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import type { SceneElement } from '@/types';
+import { PropertiesInspector } from './properties-inspector';
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+	return <TooltipProvider>{children}</TooltipProvider>;
+}
+
+const mockUpdateElement = vi.fn();
+const mockMoveElement = vi.fn();
+const mockResizeElement = vi.fn();
+const mockRotateElement = vi.fn();
+
+let mockSelectedIds: string[] = [];
+let mockElements: Record<string, SceneElement> = {};
+
+vi.mock('@/lib/stores/scene-store', () => ({
+	useSceneStore: vi.fn((selector) =>
+		selector({
+			selectedIds: mockSelectedIds,
+			elements: mockElements,
+			elementIds: Object.keys(mockElements),
+			connections: {},
+			connectionIds: [],
+			clipboard: [],
+			clipboardConnections: [],
+			camera: { x: 0, y: 0, zoom: 1 },
+			updateElement: mockUpdateElement,
+			moveElement: mockMoveElement,
+			resizeElement: mockResizeElement,
+			rotateElement: mockRotateElement,
+		}),
+	),
+}));
+
+vi.mock('next-themes', () => ({
+	useTheme: () => ({
+		theme: 'dark',
+		setTheme: vi.fn(),
+		resolvedTheme: 'dark',
+		systemTheme: 'dark',
+	}),
+}));
+
+function makeElement(overrides?: Partial<SceneElement>): SceneElement {
+	return {
+		id: 'el-1',
+		type: 'rect',
+		position: { x: 100, y: 200 },
+		size: { width: 120, height: 80 },
+		rotation: 0,
+		opacity: 1,
+		visible: true,
+		locked: false,
+		label: 'Test Label',
+		style: {
+			fill: '#2a2a4a',
+			stroke: '#6366f1',
+			strokeWidth: 2,
+			cornerRadius: 8,
+			fontSize: 14,
+			fontFamily: 'Inter, system-ui, sans-serif',
+			fontWeight: 500,
+			textColor: '#e0e0f0',
+		},
+		metadata: {},
+		...overrides,
+	};
+}
+
+describe('PropertiesInspector', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockSelectedIds = [];
+		mockElements = {};
+	});
+
+	it('shows empty state when no element is selected', () => {
+		mockSelectedIds = [];
+		render(<PropertiesInspector />, { wrapper: Wrapper });
+		expect(screen.getByText(/select an element/i)).toBeDefined();
+	});
+
+	it('shows multi-select message when multiple elements are selected', () => {
+		mockSelectedIds = ['el-1', 'el-2'];
+		mockElements = {
+			'el-1': makeElement({ id: 'el-1' }),
+			'el-2': makeElement({ id: 'el-2' }),
+		};
+		render(<PropertiesInspector />, { wrapper: Wrapper });
+		expect(screen.getByText(/2 elements selected/i)).toBeDefined();
+	});
+
+	it('displays transform section with position values', () => {
+		const el = makeElement();
+		mockSelectedIds = ['el-1'];
+		mockElements = { 'el-1': el };
+		render(<PropertiesInspector />, { wrapper: Wrapper });
+
+		// Should show X and Y position labels
+		expect(screen.getByLabelText('X')).toBeDefined();
+		expect(screen.getByLabelText('Y')).toBeDefined();
+	});
+
+	it('displays size values', () => {
+		const el = makeElement();
+		mockSelectedIds = ['el-1'];
+		mockElements = { 'el-1': el };
+		render(<PropertiesInspector />, { wrapper: Wrapper });
+
+		expect(screen.getByLabelText('W')).toBeDefined();
+		expect(screen.getByLabelText('H')).toBeDefined();
+	});
+
+	it('displays opacity slider', () => {
+		const el = makeElement();
+		mockSelectedIds = ['el-1'];
+		mockElements = { 'el-1': el };
+		render(<PropertiesInspector />, { wrapper: Wrapper });
+
+		expect(screen.getByText('Opacity')).toBeDefined();
+	});
+
+	it('displays style section with fill color', () => {
+		const el = makeElement();
+		mockSelectedIds = ['el-1'];
+		mockElements = { 'el-1': el };
+		render(<PropertiesInspector />, { wrapper: Wrapper });
+
+		expect(screen.getByText('Fill')).toBeDefined();
+	});
+
+	it('displays element type label', () => {
+		const el = makeElement({ type: 'rect' });
+		mockSelectedIds = ['el-1'];
+		mockElements = { 'el-1': el };
+		render(<PropertiesInspector />, { wrapper: Wrapper });
+
+		expect(screen.getByText('rect')).toBeDefined();
+	});
+
+	it('displays rotation input', () => {
+		const el = makeElement();
+		mockSelectedIds = ['el-1'];
+		mockElements = { 'el-1': el };
+		render(<PropertiesInspector />, { wrapper: Wrapper });
+
+		expect(screen.getByLabelText('Rotation')).toBeDefined();
+	});
+
+	it('displays stroke section', () => {
+		const el = makeElement();
+		mockSelectedIds = ['el-1'];
+		mockElements = { 'el-1': el };
+		render(<PropertiesInspector />, { wrapper: Wrapper });
+
+		expect(screen.getByText('Stroke')).toBeDefined();
+	});
+
+	it('displays corner radius', () => {
+		const el = makeElement();
+		mockSelectedIds = ['el-1'];
+		mockElements = { 'el-1': el };
+		render(<PropertiesInspector />, { wrapper: Wrapper });
+
+		expect(screen.getByText('Radius')).toBeDefined();
+	});
+});

--- a/src/components/panels/properties-inspector.tsx
+++ b/src/components/panels/properties-inspector.tsx
@@ -1,0 +1,334 @@
+'use client';
+
+import { Settings2 } from 'lucide-react';
+import { useCallback } from 'react';
+import { EmptyState } from '@/components/shared/empty-state';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Separator } from '@/components/ui/separator';
+import { Slider } from '@/components/ui/slider';
+import { useSceneStore } from '@/lib/stores/scene-store';
+import type { SceneElement } from '@/types';
+
+/**
+ * Properties Inspector panel — displays and edits properties
+ * of the currently selected scene element.
+ *
+ * Sections: Transform (position, size, rotation, opacity),
+ * Style (fill, stroke, corner radius).
+ */
+export function PropertiesInspector() {
+	const selectedIds = useSceneStore((s) => s.selectedIds);
+	const elements = useSceneStore((s) => s.elements);
+	const updateElement = useSceneStore((s) => s.updateElement);
+
+	if (selectedIds.length === 0) {
+		return (
+			<EmptyState
+				icon={Settings2}
+				title="No selection"
+				description="Select an element to view its properties"
+			/>
+		);
+	}
+
+	if (selectedIds.length > 1) {
+		return (
+			<div className="flex h-full items-center justify-center p-4">
+				<p className="text-sm text-muted-foreground">{selectedIds.length} elements selected</p>
+			</div>
+		);
+	}
+
+	const elementId = selectedIds[0];
+	if (!elementId) return null;
+	const element = elements[elementId];
+	if (!element) return null;
+
+	return (
+		<div className="space-y-3 p-3">
+			{/* Element type label */}
+			<div className="flex items-center justify-between">
+				<span className="text-xs font-medium text-muted-foreground">Type</span>
+				<span className="text-xs font-mono">{element.type}</span>
+			</div>
+
+			<Separator />
+
+			{/* Transform Section */}
+			<TransformSection element={element} onUpdate={updateElement} />
+
+			<Separator />
+
+			{/* Style Section */}
+			<StyleSection element={element} onUpdate={updateElement} />
+		</div>
+	);
+}
+
+// ── Transform Section ──
+
+function TransformSection({
+	element,
+	onUpdate,
+}: {
+	element: SceneElement;
+	onUpdate: (id: string, updates: Partial<SceneElement>) => void;
+}) {
+	const handlePositionChange = useCallback(
+		(axis: 'x' | 'y', value: string) => {
+			const num = Number(value);
+			if (Number.isNaN(num)) return;
+			onUpdate(element.id, {
+				position: { ...element.position, [axis]: num },
+			});
+		},
+		[element.id, element.position, onUpdate],
+	);
+
+	const handleSizeChange = useCallback(
+		(dim: 'width' | 'height', value: string) => {
+			const num = Number(value);
+			if (Number.isNaN(num) || num < 1) return;
+			onUpdate(element.id, {
+				size: { ...element.size, [dim]: num },
+			});
+		},
+		[element.id, element.size, onUpdate],
+	);
+
+	const handleRotationChange = useCallback(
+		(value: string) => {
+			const num = Number(value);
+			if (Number.isNaN(num)) return;
+			onUpdate(element.id, { rotation: num });
+		},
+		[element.id, onUpdate],
+	);
+
+	const handleOpacityChange = useCallback(
+		(values: number[]) => {
+			const value = values[0];
+			if (value === undefined) return;
+			onUpdate(element.id, { opacity: value / 100 });
+		},
+		[element.id, onUpdate],
+	);
+
+	return (
+		<div className="space-y-2">
+			<h3 className="text-xs font-semibold text-muted-foreground">Transform</h3>
+
+			{/* Position */}
+			<div className="grid grid-cols-2 gap-2">
+				<div className="space-y-1">
+					<Label htmlFor="pos-x" className="text-xs">
+						X
+					</Label>
+					<Input
+						id="pos-x"
+						type="number"
+						value={Math.round(element.position.x)}
+						onChange={(e) => handlePositionChange('x', e.target.value)}
+						className="h-7 text-xs"
+					/>
+				</div>
+				<div className="space-y-1">
+					<Label htmlFor="pos-y" className="text-xs">
+						Y
+					</Label>
+					<Input
+						id="pos-y"
+						type="number"
+						value={Math.round(element.position.y)}
+						onChange={(e) => handlePositionChange('y', e.target.value)}
+						className="h-7 text-xs"
+					/>
+				</div>
+			</div>
+
+			{/* Size */}
+			<div className="grid grid-cols-2 gap-2">
+				<div className="space-y-1">
+					<Label htmlFor="size-w" className="text-xs">
+						W
+					</Label>
+					<Input
+						id="size-w"
+						type="number"
+						value={Math.round(element.size.width)}
+						onChange={(e) => handleSizeChange('width', e.target.value)}
+						className="h-7 text-xs"
+					/>
+				</div>
+				<div className="space-y-1">
+					<Label htmlFor="size-h" className="text-xs">
+						H
+					</Label>
+					<Input
+						id="size-h"
+						type="number"
+						value={Math.round(element.size.height)}
+						onChange={(e) => handleSizeChange('height', e.target.value)}
+						className="h-7 text-xs"
+					/>
+				</div>
+			</div>
+
+			{/* Rotation */}
+			<div className="space-y-1">
+				<Label htmlFor="rotation" className="text-xs">
+					Rotation
+				</Label>
+				<Input
+					id="rotation"
+					type="number"
+					value={Math.round(element.rotation)}
+					onChange={(e) => handleRotationChange(e.target.value)}
+					className="h-7 text-xs"
+				/>
+			</div>
+
+			{/* Opacity */}
+			<div className="space-y-1">
+				<div className="flex items-center justify-between">
+					<span className="text-xs text-muted-foreground">Opacity</span>
+					<span className="text-xs text-muted-foreground">
+						{Math.round(element.opacity * 100)}%
+					</span>
+				</div>
+				<Slider
+					value={[Math.round(element.opacity * 100)]}
+					min={0}
+					max={100}
+					step={1}
+					onValueChange={handleOpacityChange}
+					aria-label="Opacity"
+				/>
+			</div>
+		</div>
+	);
+}
+
+// ── Style Section ──
+
+function StyleSection({
+	element,
+	onUpdate,
+}: {
+	element: SceneElement;
+	onUpdate: (id: string, updates: Partial<SceneElement>) => void;
+}) {
+	const handleFillChange = useCallback(
+		(value: string) => {
+			onUpdate(element.id, {
+				style: { ...element.style, fill: value },
+			});
+		},
+		[element.id, element.style, onUpdate],
+	);
+
+	const handleStrokeChange = useCallback(
+		(value: string) => {
+			onUpdate(element.id, {
+				style: { ...element.style, stroke: value },
+			});
+		},
+		[element.id, element.style, onUpdate],
+	);
+
+	const handleStrokeWidthChange = useCallback(
+		(value: string) => {
+			const num = Number(value);
+			if (Number.isNaN(num) || num < 0) return;
+			onUpdate(element.id, {
+				style: { ...element.style, strokeWidth: num },
+			});
+		},
+		[element.id, element.style, onUpdate],
+	);
+
+	const handleCornerRadiusChange = useCallback(
+		(values: number[]) => {
+			const value = values[0];
+			if (value === undefined) return;
+			onUpdate(element.id, {
+				style: { ...element.style, cornerRadius: value },
+			});
+		},
+		[element.id, element.style, onUpdate],
+	);
+
+	return (
+		<div className="space-y-2">
+			<h3 className="text-xs font-semibold text-muted-foreground">Style</h3>
+
+			{/* Fill */}
+			<div className="flex items-center gap-2">
+				<span className="w-10 text-xs text-muted-foreground">Fill</span>
+				<input
+					type="color"
+					value={element.style.fill}
+					onChange={(e) => handleFillChange(e.target.value)}
+					className="h-6 w-6 cursor-pointer rounded border-0"
+					aria-label="Fill color"
+				/>
+				<Input
+					type="text"
+					value={element.style.fill}
+					onChange={(e) => handleFillChange(e.target.value)}
+					className="h-7 flex-1 font-mono text-xs"
+					aria-label="Fill hex value"
+				/>
+			</div>
+
+			{/* Stroke */}
+			<div className="flex items-center gap-2">
+				<span className="w-10 text-xs text-muted-foreground">Stroke</span>
+				<input
+					type="color"
+					value={element.style.stroke}
+					onChange={(e) => handleStrokeChange(e.target.value)}
+					className="h-6 w-6 cursor-pointer rounded border-0"
+					aria-label="Stroke color"
+				/>
+				<Input
+					type="text"
+					value={element.style.stroke}
+					onChange={(e) => handleStrokeChange(e.target.value)}
+					className="h-7 flex-1 font-mono text-xs"
+					aria-label="Stroke hex value"
+				/>
+			</div>
+
+			{/* Stroke Width */}
+			<div className="flex items-center gap-2">
+				<span className="w-16 text-xs text-muted-foreground">Width</span>
+				<Input
+					type="number"
+					value={element.style.strokeWidth}
+					onChange={(e) => handleStrokeWidthChange(e.target.value)}
+					className="h-7 text-xs"
+					min={0}
+					aria-label="Stroke width"
+				/>
+			</div>
+
+			{/* Corner Radius */}
+			<div className="space-y-1">
+				<div className="flex items-center justify-between">
+					<span className="text-xs text-muted-foreground">Radius</span>
+					<span className="text-xs text-muted-foreground">{element.style.cornerRadius}px</span>
+				</div>
+				<Slider
+					value={[element.style.cornerRadius]}
+					min={0}
+					max={50}
+					step={1}
+					onValueChange={handleCornerRadiusChange}
+					aria-label="Corner radius"
+				/>
+			</div>
+		</div>
+	);
+}

--- a/src/components/panels/right-panel.tsx
+++ b/src/components/panels/right-panel.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { Settings2, Sparkles } from 'lucide-react';
+import { Sparkles } from 'lucide-react';
+import { PropertiesInspector } from '@/components/panels/properties-inspector';
 import { EmptyState } from '@/components/shared/empty-state';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
@@ -18,11 +19,7 @@ export function RightPanel() {
 			</TabsList>
 			<ScrollArea className="flex-1">
 				<TabsContent value="properties" className="mt-0">
-					<EmptyState
-						icon={Settings2}
-						title="No selection"
-						description="Select an element to view its properties"
-					/>
+					<PropertiesInspector />
 				</TabsContent>
 				<TabsContent value="animation" className="mt-0">
 					<EmptyState


### PR DESCRIPTION
## Summary
- Built `PropertiesInspector` component with Transform section (position X/Y, size W/H, rotation, opacity slider) and Style section (fill/stroke color pickers with hex input, stroke width, corner radius slider)
- Empty state when no selection, multi-select count when multiple elements selected
- Wired into `RightPanel` replacing the placeholder EmptyState
- All changes are immediate via `useSceneStore.updateElement()`

## Test plan
- [x] 10 unit tests: empty state, multi-select, position inputs, size inputs, opacity, fill, element type label, rotation, stroke, corner radius
- [x] All 766 tests pass (`pnpm vitest run`)
- [x] Biome lint + format clean
- [x] TypeScript strict mode passes

Closes #28

🤖 Generated with [Claude Code](https://claude.com/claude-code)