### PR TITLE
feat: build template library with browse, search, and load (#29)

### DIFF
--- a/src/components/panels/left-panel.tsx
+++ b/src/components/panels/left-panel.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import { Layers, LayoutTemplate } from 'lucide-react';
+import { Layers } from 'lucide-react';
 import { EmptyState } from '@/components/shared/empty-state';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 import { ElementLibrary } from './element-library';
+import { TemplateGallery } from './template-gallery';
 
 export function LeftPanel() {
 	return (
@@ -25,11 +26,7 @@ export function LeftPanel() {
 					<ElementLibrary />
 				</TabsContent>
 				<TabsContent value="templates" className="mt-0">
-					<EmptyState
-						icon={LayoutTemplate}
-						title="Templates"
-						description="Browse and load pre-built algorithm templates"
-					/>
+					<TemplateGallery />
 				</TabsContent>
 				<TabsContent value="layers" className="mt-0">
 					<EmptyState

--- a/src/components/panels/template-gallery.test.tsx
+++ b/src/components/panels/template-gallery.test.tsx
@@ -1,0 +1,84 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import { TemplateGallery } from './template-gallery';
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+	return <TooltipProvider>{children}</TooltipProvider>;
+}
+
+const mockAddElement = vi.fn();
+const mockDeselectAll = vi.fn();
+const mockReset = vi.fn();
+
+vi.mock('@/lib/stores/scene-store', () => ({
+	useSceneStore: vi.fn((selector) =>
+		selector({
+			selectedIds: [],
+			elements: {},
+			elementIds: [],
+			connections: {},
+			connectionIds: [],
+			clipboard: [],
+			clipboardConnections: [],
+			camera: { x: 0, y: 0, zoom: 1 },
+			addElement: mockAddElement,
+			deselectAll: mockDeselectAll,
+			reset: mockReset,
+		}),
+	),
+}));
+
+vi.mock('next-themes', () => ({
+	useTheme: () => ({
+		theme: 'dark',
+		setTheme: vi.fn(),
+		resolvedTheme: 'dark',
+		systemTheme: 'dark',
+	}),
+}));
+
+describe('TemplateGallery', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('renders template gallery with templates', () => {
+		render(<TemplateGallery />, { wrapper: Wrapper });
+		// Should show at least one template name
+		expect(screen.getByText('Bubble Sort')).toBeDefined();
+	});
+
+	it('renders category filter tabs', () => {
+		render(<TemplateGallery />, { wrapper: Wrapper });
+		expect(screen.getByText('All')).toBeDefined();
+		expect(screen.getByText('Sorting')).toBeDefined();
+	});
+
+	it('renders search input', () => {
+		render(<TemplateGallery />, { wrapper: Wrapper });
+		expect(screen.getByPlaceholderText(/search/i)).toBeDefined();
+	});
+
+	it('filters templates by search', async () => {
+		const user = userEvent.setup();
+		render(<TemplateGallery />, { wrapper: Wrapper });
+
+		await user.type(screen.getByPlaceholderText(/search/i), 'binary');
+		expect(screen.getByText('Binary Search')).toBeDefined();
+	});
+
+	it('shows template difficulty badge', () => {
+		render(<TemplateGallery />, { wrapper: Wrapper });
+		// At least one beginner template
+		expect(screen.getAllByText('beginner').length).toBeGreaterThan(0);
+	});
+
+	it('shows template descriptions', () => {
+		render(<TemplateGallery />, { wrapper: Wrapper });
+		// Each template card should have a description
+		const descriptions = screen.getAllByRole('article');
+		expect(descriptions.length).toBeGreaterThan(0);
+	});
+});

--- a/src/components/panels/template-gallery.tsx
+++ b/src/components/panels/template-gallery.tsx
@@ -1,0 +1,102 @@
+'use client';
+
+import { Search } from 'lucide-react';
+import { useMemo, useState } from 'react';
+import { Badge } from '@/components/ui/badge';
+import { Input } from '@/components/ui/input';
+import { Tabs, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { useSceneStore } from '@/lib/stores/scene-store';
+import { filterTemplates, TEMPLATE_CATEGORIES, type Template } from '@/lib/templates/templates';
+
+function TemplateCard({
+	template,
+	onLoad,
+}: {
+	template: Template;
+	onLoad: (template: Template) => void;
+}) {
+	return (
+		<article className="cursor-pointer rounded-lg border p-3 transition-colors hover:border-primary/50 hover:bg-accent">
+			<button type="button" className="w-full text-left" onClick={() => onLoad(template)}>
+				<div className="mb-1 flex items-center justify-between gap-2">
+					<h4 className="text-xs font-medium">{template.name}</h4>
+					<Badge variant="outline" className="text-[10px]">
+						{template.difficulty}
+					</Badge>
+				</div>
+				<p className="text-[11px] leading-snug text-muted-foreground">{template.description}</p>
+			</button>
+		</article>
+	);
+}
+
+export function TemplateGallery() {
+	const [search, setSearch] = useState('');
+	const [activeCategory, setActiveCategory] = useState('All');
+	const addElement = useSceneStore((s) => s.addElement);
+	const deselectAll = useSceneStore((s) => s.deselectAll);
+	const reset = useSceneStore((s) => s.reset);
+
+	const filtered = useMemo(() => {
+		return filterTemplates({
+			query: search || undefined,
+			category: activeCategory === 'All' ? undefined : activeCategory,
+		});
+	}, [search, activeCategory]);
+
+	function handleLoad(template: Template) {
+		reset();
+		deselectAll();
+		for (const element of template.elements) {
+			addElement(element);
+		}
+	}
+
+	return (
+		<div className="flex h-full flex-col">
+			{/* Search */}
+			<div className="border-b p-2">
+				<div className="relative">
+					<Search className="absolute top-1/2 left-2.5 h-3.5 w-3.5 -translate-y-1/2 text-muted-foreground" />
+					<Input
+						placeholder="Search templates..."
+						value={search}
+						onChange={(e) => setSearch(e.target.value)}
+						className="h-7 pl-8 text-xs"
+					/>
+				</div>
+			</div>
+
+			{/* Category Tabs */}
+			<div className="border-b px-2 py-1">
+				<Tabs value={activeCategory} onValueChange={setActiveCategory}>
+					<TabsList className="h-7 bg-transparent">
+						<TabsTrigger value="All" className="h-5 text-[10px]">
+							All
+						</TabsTrigger>
+						{TEMPLATE_CATEGORIES.map((cat) => (
+							<TabsTrigger key={cat} value={cat} className="h-5 text-[10px]">
+								{cat}
+							</TabsTrigger>
+						))}
+					</TabsList>
+				</Tabs>
+			</div>
+
+			{/* Template Grid */}
+			<div className="flex-1 overflow-y-auto p-2">
+				{filtered.length > 0 ? (
+					<div className="space-y-2">
+						{filtered.map((template) => (
+							<TemplateCard key={template.id} template={template} onLoad={handleLoad} />
+						))}
+					</div>
+				) : (
+					<div className="flex items-center justify-center p-8">
+						<p className="text-xs text-muted-foreground">No templates found</p>
+					</div>
+				)}
+			</div>
+		</div>
+	);
+}

--- a/src/lib/templates/templates.test.ts
+++ b/src/lib/templates/templates.test.ts
@@ -1,0 +1,99 @@
+import { describe, expect, it } from 'vitest';
+import {
+	filterTemplates,
+	getTemplateById,
+	getTemplatesByCategory,
+	TEMPLATE_CATEGORIES,
+	TEMPLATE_DIFFICULTIES,
+	templates,
+} from './templates';
+
+describe('templates', () => {
+	it('has at least 10 starter templates', () => {
+		expect(templates.length).toBeGreaterThanOrEqual(10);
+	});
+
+	it('all templates have required fields', () => {
+		for (const t of templates) {
+			expect(t.id).toBeTruthy();
+			expect(t.name).toBeTruthy();
+			expect(t.description).toBeTruthy();
+			expect(t.category).toBeTruthy();
+			expect(TEMPLATE_DIFFICULTIES).toContain(t.difficulty);
+			expect(t.tags.length).toBeGreaterThan(0);
+			expect(t.elements.length).toBeGreaterThan(0);
+		}
+	});
+
+	it('all template IDs are unique', () => {
+		const ids = templates.map((t) => t.id);
+		expect(new Set(ids).size).toBe(ids.length);
+	});
+});
+
+describe('TEMPLATE_CATEGORIES', () => {
+	it('has at least 5 categories', () => {
+		expect(TEMPLATE_CATEGORIES.length).toBeGreaterThanOrEqual(5);
+	});
+});
+
+describe('getTemplateById', () => {
+	it('returns the template with the given ID', () => {
+		const t = getTemplateById('bubble-sort');
+		expect(t).toBeDefined();
+		expect(t?.name).toContain('Bubble Sort');
+	});
+
+	it('returns undefined for unknown ID', () => {
+		expect(getTemplateById('nonexistent')).toBeUndefined();
+	});
+});
+
+describe('getTemplatesByCategory', () => {
+	it('returns templates in the given category', () => {
+		const sorting = getTemplatesByCategory('Sorting');
+		expect(sorting.length).toBeGreaterThan(0);
+		for (const t of sorting) {
+			expect(t.category).toBe('Sorting');
+		}
+	});
+
+	it('returns empty array for unknown category', () => {
+		expect(getTemplatesByCategory('NoSuchCategory')).toEqual([]);
+	});
+});
+
+describe('filterTemplates', () => {
+	it('filters by search query (name)', () => {
+		const results = filterTemplates({ query: 'bubble' });
+		expect(results.length).toBeGreaterThan(0);
+		expect(results[0]?.name.toLowerCase()).toContain('bubble');
+	});
+
+	it('filters by category', () => {
+		const results = filterTemplates({ category: 'Searching' });
+		for (const t of results) {
+			expect(t.category).toBe('Searching');
+		}
+	});
+
+	it('filters by difficulty', () => {
+		const results = filterTemplates({ difficulty: 'beginner' });
+		for (const t of results) {
+			expect(t.difficulty).toBe('beginner');
+		}
+	});
+
+	it('combines filters', () => {
+		const results = filterTemplates({ category: 'Sorting', difficulty: 'beginner' });
+		for (const t of results) {
+			expect(t.category).toBe('Sorting');
+			expect(t.difficulty).toBe('beginner');
+		}
+	});
+
+	it('returns all templates with empty filter', () => {
+		const results = filterTemplates({});
+		expect(results.length).toBe(templates.length);
+	});
+});

--- a/src/lib/templates/templates.ts
+++ b/src/lib/templates/templates.ts
@@ -1,0 +1,274 @@
+import type { SceneElement } from '@/types';
+
+// ── Types ──
+
+export interface Template {
+	id: string;
+	name: string;
+	description: string;
+	category: string;
+	difficulty: TemplateDifficulty;
+	tags: string[];
+	elements: SceneElement[];
+}
+
+export type TemplateDifficulty = 'beginner' | 'intermediate' | 'advanced';
+
+export interface TemplateFilter {
+	query?: string;
+	category?: string;
+	difficulty?: TemplateDifficulty;
+}
+
+// ── Constants ──
+
+export const TEMPLATE_CATEGORIES = [
+	'Sorting',
+	'Searching',
+	'Graph',
+	'Data Structures',
+	'Trees',
+] as const;
+
+export const TEMPLATE_DIFFICULTIES: TemplateDifficulty[] = ['beginner', 'intermediate', 'advanced'];
+
+// ── Helper: default element style ──
+
+const DEFAULT_STYLE = {
+	fill: '#2a2a4a',
+	stroke: '#6366f1',
+	strokeWidth: 2,
+	cornerRadius: 8,
+	fontSize: 14,
+	fontFamily: 'Inter, system-ui, sans-serif',
+	fontWeight: 500,
+	textColor: '#e0e0f0',
+} as const;
+
+function makeCell(
+	id: string,
+	x: number,
+	y: number,
+	label: string,
+	type: SceneElement['type'] = 'arrayCell',
+): SceneElement {
+	return {
+		id,
+		type,
+		position: { x, y },
+		size: { width: 60, height: 60 },
+		rotation: 0,
+		opacity: 1,
+		visible: true,
+		locked: false,
+		label,
+		style: { ...DEFAULT_STYLE },
+		metadata: {},
+	};
+}
+
+// ── Starter Templates ──
+
+export const templates: Template[] = [
+	{
+		id: 'bubble-sort',
+		name: 'Bubble Sort',
+		description: 'Compare adjacent elements and swap them if they are in the wrong order.',
+		category: 'Sorting',
+		difficulty: 'beginner',
+		tags: ['sorting', 'comparison', 'in-place', 'stable'],
+		elements: [
+			makeCell('bs-0', 40, 100, '5'),
+			makeCell('bs-1', 110, 100, '3'),
+			makeCell('bs-2', 180, 100, '8'),
+			makeCell('bs-3', 250, 100, '1'),
+			makeCell('bs-4', 320, 100, '4'),
+		],
+	},
+	{
+		id: 'selection-sort',
+		name: 'Selection Sort',
+		description: 'Find the minimum element and place it at the beginning repeatedly.',
+		category: 'Sorting',
+		difficulty: 'beginner',
+		tags: ['sorting', 'comparison', 'in-place'],
+		elements: [
+			makeCell('ss-0', 40, 100, '7'),
+			makeCell('ss-1', 110, 100, '2'),
+			makeCell('ss-2', 180, 100, '9'),
+			makeCell('ss-3', 250, 100, '4'),
+			makeCell('ss-4', 320, 100, '1'),
+		],
+	},
+	{
+		id: 'insertion-sort',
+		name: 'Insertion Sort',
+		description: 'Build a sorted array one element at a time by inserting into position.',
+		category: 'Sorting',
+		difficulty: 'beginner',
+		tags: ['sorting', 'comparison', 'in-place', 'stable', 'adaptive'],
+		elements: [
+			makeCell('is-0', 40, 100, '6'),
+			makeCell('is-1', 110, 100, '3'),
+			makeCell('is-2', 180, 100, '8'),
+			makeCell('is-3', 250, 100, '2'),
+		],
+	},
+	{
+		id: 'merge-sort',
+		name: 'Merge Sort',
+		description: 'Divide the array into halves, sort each half, then merge them back.',
+		category: 'Sorting',
+		difficulty: 'intermediate',
+		tags: ['sorting', 'divide-and-conquer', 'stable', 'recursive'],
+		elements: [
+			makeCell('ms-0', 40, 60, '4'),
+			makeCell('ms-1', 110, 60, '7'),
+			makeCell('ms-2', 180, 60, '2'),
+			makeCell('ms-3', 250, 60, '5'),
+			makeCell('ms-4', 320, 60, '1'),
+			makeCell('ms-5', 390, 60, '6'),
+		],
+	},
+	{
+		id: 'quick-sort',
+		name: 'Quick Sort',
+		description: 'Pick a pivot, partition elements around it, and recursively sort.',
+		category: 'Sorting',
+		difficulty: 'intermediate',
+		tags: ['sorting', 'divide-and-conquer', 'in-place', 'recursive'],
+		elements: [
+			makeCell('qs-0', 40, 100, '6'),
+			makeCell('qs-1', 110, 100, '3'),
+			makeCell('qs-2', 180, 100, '9'),
+			makeCell('qs-3', 250, 100, '1'),
+			makeCell('qs-4', 320, 100, '7'),
+		],
+	},
+	{
+		id: 'binary-search',
+		name: 'Binary Search',
+		description: 'Efficiently search a sorted array by repeatedly dividing the search range.',
+		category: 'Searching',
+		difficulty: 'beginner',
+		tags: ['searching', 'divide-and-conquer', 'sorted-input'],
+		elements: [
+			makeCell('bin-0', 40, 100, '1'),
+			makeCell('bin-1', 110, 100, '3'),
+			makeCell('bin-2', 180, 100, '5'),
+			makeCell('bin-3', 250, 100, '7'),
+			makeCell('bin-4', 320, 100, '9'),
+			makeCell('bin-5', 390, 100, '11'),
+		],
+	},
+	{
+		id: 'linear-search',
+		name: 'Linear Search',
+		description: 'Scan through each element one by one until the target is found.',
+		category: 'Searching',
+		difficulty: 'beginner',
+		tags: ['searching', 'sequential', 'unsorted'],
+		elements: [
+			makeCell('ls-0', 40, 100, '4'),
+			makeCell('ls-1', 110, 100, '7'),
+			makeCell('ls-2', 180, 100, '2'),
+			makeCell('ls-3', 250, 100, '9'),
+			makeCell('ls-4', 320, 100, '5'),
+		],
+	},
+	{
+		id: 'bfs-traversal',
+		name: 'BFS Traversal',
+		description: 'Explore a graph level by level using a queue.',
+		category: 'Graph',
+		difficulty: 'intermediate',
+		tags: ['graph', 'traversal', 'queue', 'shortest-path'],
+		elements: [
+			makeCell('bfs-0', 200, 40, 'A', 'graphNode'),
+			makeCell('bfs-1', 120, 120, 'B', 'graphNode'),
+			makeCell('bfs-2', 280, 120, 'C', 'graphNode'),
+			makeCell('bfs-3', 80, 200, 'D', 'graphNode'),
+			makeCell('bfs-4', 200, 200, 'E', 'graphNode'),
+		],
+	},
+	{
+		id: 'dfs-traversal',
+		name: 'DFS Traversal',
+		description: 'Explore a graph by going as deep as possible before backtracking.',
+		category: 'Graph',
+		difficulty: 'intermediate',
+		tags: ['graph', 'traversal', 'stack', 'recursive'],
+		elements: [
+			makeCell('dfs-0', 200, 40, 'A', 'graphNode'),
+			makeCell('dfs-1', 120, 120, 'B', 'graphNode'),
+			makeCell('dfs-2', 280, 120, 'C', 'graphNode'),
+			makeCell('dfs-3', 80, 200, 'D', 'graphNode'),
+		],
+	},
+	{
+		id: 'stack-operations',
+		name: 'Stack Operations',
+		description: 'Push and pop elements on a LIFO stack data structure.',
+		category: 'Data Structures',
+		difficulty: 'beginner',
+		tags: ['data-structure', 'stack', 'lifo', 'push', 'pop'],
+		elements: [
+			makeCell('stk-0', 100, 40, '10', 'stackFrame'),
+			makeCell('stk-1', 100, 110, '20', 'stackFrame'),
+			makeCell('stk-2', 100, 180, '30', 'stackFrame'),
+		],
+	},
+	{
+		id: 'queue-operations',
+		name: 'Queue Operations',
+		description: 'Enqueue and dequeue elements on a FIFO queue data structure.',
+		category: 'Data Structures',
+		difficulty: 'beginner',
+		tags: ['data-structure', 'queue', 'fifo', 'enqueue', 'dequeue'],
+		elements: [
+			makeCell('q-0', 40, 100, 'A', 'queueCell'),
+			makeCell('q-1', 110, 100, 'B', 'queueCell'),
+			makeCell('q-2', 180, 100, 'C', 'queueCell'),
+		],
+	},
+	{
+		id: 'binary-tree-traversal',
+		name: 'Binary Tree Traversal',
+		description: 'Traverse a binary tree using inorder, preorder, or postorder strategies.',
+		category: 'Trees',
+		difficulty: 'intermediate',
+		tags: ['tree', 'traversal', 'recursive', 'binary-tree'],
+		elements: [
+			makeCell('bt-0', 200, 40, '8', 'treeNode'),
+			makeCell('bt-1', 120, 120, '4', 'treeNode'),
+			makeCell('bt-2', 280, 120, '12', 'treeNode'),
+			makeCell('bt-3', 80, 200, '2', 'treeNode'),
+			makeCell('bt-4', 160, 200, '6', 'treeNode'),
+		],
+	},
+];
+
+// ── Query Functions ──
+
+export function getTemplateById(id: string): Template | undefined {
+	return templates.find((t) => t.id === id);
+}
+
+export function getTemplatesByCategory(category: string): Template[] {
+	return templates.filter((t) => t.category === category);
+}
+
+export function filterTemplates(filter: TemplateFilter): Template[] {
+	return templates.filter((t) => {
+		if (filter.query) {
+			const q = filter.query.toLowerCase();
+			const matchesName = t.name.toLowerCase().includes(q);
+			const matchesDesc = t.description.toLowerCase().includes(q);
+			const matchesTags = t.tags.some((tag) => tag.toLowerCase().includes(q));
+			if (!matchesName && !matchesDesc && !matchesTags) return false;
+		}
+		if (filter.category && t.category !== filter.category) return false;
+		if (filter.difficulty && t.difficulty !== filter.difficulty) return false;
+		return true;
+	});
+}


### PR DESCRIPTION
## Summary
- Add `src/lib/templates/templates.ts` with `Template` type, 12 starter templates across 5 categories (Sorting, Searching, Graph, Data Structures, Trees), difficulty levels, and filter/query functions (`getTemplateById`, `getTemplatesByCategory`, `filterTemplates`)
- Add `src/components/panels/template-gallery.tsx` — browsable gallery with category tabs, search input, difficulty badges, and click-to-load template cards
- Wire `TemplateGallery` into left panel, replacing the EmptyState placeholder

## Test plan
- [x] 13 unit tests for template data module (count, required fields, unique IDs, categories, filter functions)
- [x] 6 component tests for gallery UI (rendering, category tabs, search, filtering, difficulty badges, template cards)
- [x] All 785 tests pass
- [x] Biome lint/format clean
- [x] TypeScript strict mode clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)