### PR TITLE
feat: build call stack display panel with expandable frames (#35)

### DIFF
--- a/src/components/debug/call-stack-panel.test.tsx
+++ b/src/components/debug/call-stack-panel.test.tsx
@@ -1,0 +1,191 @@
+import { render, screen, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { TooltipProvider } from '@/components/ui/tooltip';
+import type { StackFrame } from '@/types';
+import { CallStackPanel } from './call-stack-panel';
+
+function Wrapper({ children }: { children: React.ReactNode }) {
+	return <TooltipProvider>{children}</TooltipProvider>;
+}
+
+let mockCallStack: StackFrame[] = [];
+let mockStatus = 'idle' as string;
+const mockSetCurrentLine = vi.fn();
+
+vi.mock('@/lib/stores/execution-store', () => ({
+	useExecutionStore: vi.fn((selector) =>
+		selector({
+			executionState: {
+				callStack: mockCallStack,
+				status: mockStatus,
+				currentLine: 0,
+				visitedLines: [],
+				nextLine: 0,
+				variables: {},
+				heap: {},
+				output: [],
+				stepCount: 0,
+				animationTime: 0,
+				lineAnnotations: {},
+			},
+			breakpoints: [],
+			sourceCode: '',
+			setCurrentLine: mockSetCurrentLine,
+		}),
+	),
+}));
+
+vi.mock('next-themes', () => ({
+	useTheme: () => ({
+		theme: 'dark',
+		setTheme: vi.fn(),
+		resolvedTheme: 'dark',
+		systemTheme: 'dark',
+	}),
+}));
+
+function makeFrame(
+	functionName: string,
+	lineNumber: number,
+	localVariables?: Record<string, unknown>,
+): StackFrame {
+	return {
+		functionName,
+		lineNumber,
+		localVariables: (localVariables ?? {}) as StackFrame['localVariables'],
+		returnAddress: 0,
+	};
+}
+
+describe('CallStackPanel', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+		mockCallStack = [];
+		mockStatus = 'idle';
+	});
+
+	it('shows empty state when no stack frames exist', () => {
+		render(<CallStackPanel />, { wrapper: Wrapper });
+		expect(screen.getByText(/no call stack/i)).toBeDefined();
+	});
+
+	it('displays stack frames with function names', () => {
+		mockCallStack = [makeFrame('main', 1), makeFrame('bubbleSort', 5)];
+		mockStatus = 'paused';
+		render(<CallStackPanel />, { wrapper: Wrapper });
+
+		expect(screen.getByText('main')).toBeDefined();
+		expect(screen.getByText('bubbleSort')).toBeDefined();
+	});
+
+	it('displays line numbers for each frame', () => {
+		mockCallStack = [makeFrame('main', 1), makeFrame('swap', 12)];
+		mockStatus = 'paused';
+		render(<CallStackPanel />, { wrapper: Wrapper });
+
+		expect(screen.getByText(/^Line 1$/)).toBeDefined();
+		expect(screen.getByText(/^Line 12$/)).toBeDefined();
+	});
+
+	it('shows current (top) frame with a visual indicator', () => {
+		mockCallStack = [makeFrame('main', 1), makeFrame('sort', 5)];
+		mockStatus = 'paused';
+		render(<CallStackPanel />, { wrapper: Wrapper });
+
+		// The top frame (last in array = most recent) should have a distinct style
+		const items = screen.getAllByRole('listitem');
+		const topFrame = items[0];
+		expect(topFrame?.className).toMatch(/current/);
+	});
+
+	it('shows frames in reverse order (most recent on top)', () => {
+		mockCallStack = [makeFrame('main', 1), makeFrame('outer', 5), makeFrame('inner', 10)];
+		mockStatus = 'paused';
+		render(<CallStackPanel />, { wrapper: Wrapper });
+
+		const items = screen.getAllByRole('listitem');
+		expect(within(items[0] as HTMLElement).getByText('inner')).toBeDefined();
+		expect(within(items[1] as HTMLElement).getByText('outer')).toBeDefined();
+		expect(within(items[2] as HTMLElement).getByText('main')).toBeDefined();
+	});
+
+	it('navigates to frame line on click', async () => {
+		const user = userEvent.setup();
+		mockCallStack = [makeFrame('main', 1), makeFrame('sort', 15)];
+		mockStatus = 'paused';
+		render(<CallStackPanel />, { wrapper: Wrapper });
+
+		// Click on the 'main' frame (bottom frame = second item)
+		const mainButton = screen.getByText('main').closest('button') as HTMLElement;
+		await user.click(mainButton);
+
+		expect(mockSetCurrentLine).toHaveBeenCalledWith(1);
+	});
+
+	it('shows local variables when frame is expanded', async () => {
+		const user = userEvent.setup();
+		mockCallStack = [makeFrame('main', 1, { x: 5, name: 'hello' })];
+		mockStatus = 'paused';
+		render(<CallStackPanel />, { wrapper: Wrapper });
+
+		// Expand the frame to see local variables
+		const expandButton = screen.getByLabelText(/expand/i);
+		await user.click(expandButton);
+
+		expect(screen.getByText('x')).toBeDefined();
+		expect(screen.getByText('5')).toBeDefined();
+		expect(screen.getByText('name')).toBeDefined();
+	});
+
+	it('shows frame with no local variables as empty when expanded', async () => {
+		const user = userEvent.setup();
+		mockCallStack = [makeFrame('main', 1)];
+		mockStatus = 'paused';
+		render(<CallStackPanel />, { wrapper: Wrapper });
+
+		const expandButton = screen.getByLabelText(/expand/i);
+		await user.click(expandButton);
+
+		expect(screen.getByText(/no local variables/i)).toBeDefined();
+	});
+
+	it('displays frame depth count in toolbar', () => {
+		mockCallStack = [makeFrame('main', 1), makeFrame('sort', 5), makeFrame('swap', 10)];
+		mockStatus = 'running';
+		render(<CallStackPanel />, { wrapper: Wrapper });
+
+		expect(screen.getByText(/3 frames/i)).toBeDefined();
+	});
+
+	it('displays singular "frame" for single frame', () => {
+		mockCallStack = [makeFrame('main', 1)];
+		mockStatus = 'running';
+		render(<CallStackPanel />, { wrapper: Wrapper });
+
+		expect(screen.getByText(/1 frame$/i)).toBeDefined();
+	});
+
+	it('has ARIA live region for accessibility', () => {
+		mockCallStack = [makeFrame('main', 1)];
+		mockStatus = 'running';
+		render(<CallStackPanel />, { wrapper: Wrapper });
+
+		const liveRegion = screen.getByRole('list');
+		expect(liveRegion.getAttribute('aria-live')).toBe('polite');
+	});
+
+	it('formats value for display in local variables', async () => {
+		const user = userEvent.setup();
+		mockCallStack = [makeFrame('fn', 1, { arr: [1, 2, 3], flag: true, s: 'test' })];
+		mockStatus = 'paused';
+		render(<CallStackPanel />, { wrapper: Wrapper });
+
+		const expandButton = screen.getByLabelText(/expand/i);
+		await user.click(expandButton);
+
+		expect(screen.getByText('[1, 2, 3]')).toBeDefined();
+		expect(screen.getByText('true')).toBeDefined();
+		expect(screen.getByText('"test"')).toBeDefined();
+	});
+});

--- a/src/components/debug/call-stack-panel.tsx
+++ b/src/components/debug/call-stack-panel.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { ChevronRight, Layers } from 'lucide-react';
+import { useState } from 'react';
+import { EmptyState } from '@/components/shared/empty-state';
+import { useExecutionStore } from '@/lib/stores/execution-store';
+import type { JsonValue, StackFrame } from '@/types';
+
+function formatValue(value: unknown): string {
+	if (value === null) return 'null';
+	if (value === undefined) return 'undefined';
+	if (typeof value === 'string') return `"${value}"`;
+	if (typeof value === 'boolean') return String(value);
+	if (typeof value === 'number') return String(value);
+	if (Array.isArray(value)) return `[${value.join(', ')}]`;
+	if (typeof value === 'object') return JSON.stringify(value);
+	return String(value);
+}
+
+function FrameVariables({ variables }: { variables: Record<string, JsonValue> }) {
+	const entries = Object.entries(variables);
+	if (entries.length === 0) {
+		return <p className="px-6 py-1 text-[10px] text-muted-foreground/60">No local variables</p>;
+	}
+	return (
+		<div className="border-t border-border/20 bg-muted/30 px-6 py-1">
+			{entries.map(([name, value]) => (
+				<div key={name} className="flex items-center gap-2 py-0.5 font-mono text-[10px]">
+					<span className="text-foreground/80">{name}</span>
+					<span className="text-muted-foreground">=</span>
+					<span className="text-blue-400">{formatValue(value)}</span>
+				</div>
+			))}
+		</div>
+	);
+}
+
+function StackFrameItem({
+	frame,
+	isCurrent,
+	onNavigate,
+}: {
+	frame: StackFrame;
+	isCurrent: boolean;
+	onNavigate: (line: number) => void;
+}) {
+	const [expanded, setExpanded] = useState(false);
+
+	return (
+		<li className={`border-b border-border/30 ${isCurrent ? 'current bg-blue-500/10' : ''}`}>
+			<div className="flex items-center">
+				<button
+					type="button"
+					className="flex items-center px-1 py-1 text-muted-foreground/60 hover:text-foreground"
+					onClick={() => setExpanded(!expanded)}
+					aria-label={expanded ? 'Collapse frame' : 'Expand frame'}
+				>
+					<ChevronRight className={`size-3 transition-transform ${expanded ? 'rotate-90' : ''}`} />
+				</button>
+				<button
+					type="button"
+					className="flex flex-1 items-center gap-2 py-1 pr-2 text-left text-xs hover:bg-muted/50"
+					onClick={() => onNavigate(frame.lineNumber)}
+				>
+					{isCurrent && <span className="size-1.5 rounded-full bg-blue-400" />}
+					<span className="font-mono font-medium">{frame.functionName}</span>
+					<span className="text-muted-foreground/60">Line {frame.lineNumber}</span>
+				</button>
+			</div>
+			{expanded && <FrameVariables variables={frame.localVariables} />}
+		</li>
+	);
+}
+
+export function CallStackPanel() {
+	const callStack = useExecutionStore((s) => s.executionState.callStack);
+	const setCurrentLine = useExecutionStore((s) => s.setCurrentLine);
+
+	// Reverse so most recent frame is on top
+	const frames = [...callStack].reverse();
+
+	if (frames.length === 0) {
+		return (
+			<EmptyState
+				icon={Layers}
+				title="No call stack"
+				description="The call stack will appear here during code execution"
+			/>
+		);
+	}
+
+	return (
+		<div className="flex h-full flex-col">
+			{/* Toolbar */}
+			<div className="flex items-center justify-between border-b px-2 py-1">
+				<span className="text-xs font-medium text-muted-foreground">
+					{frames.length} frame{frames.length !== 1 ? 's' : ''}
+				</span>
+			</div>
+
+			{/* Stack frames list */}
+			<ul aria-live="polite" className="flex-1 overflow-y-auto">
+				{frames.map((frame, i) => (
+					<StackFrameItem
+						key={`${frame.functionName}-${frame.lineNumber}-${i}`}
+						frame={frame}
+						isCurrent={i === 0}
+						onNavigate={setCurrentLine}
+					/>
+				))}
+			</ul>
+		</div>
+	);
+}

--- a/src/components/panels/bottom-panel.tsx
+++ b/src/components/panels/bottom-panel.tsx
@@ -2,6 +2,7 @@
 
 import { FileCode2 } from 'lucide-react';
 import dynamic from 'next/dynamic';
+import { CallStackPanel } from '@/components/debug/call-stack-panel';
 import { VariableWatchPanel } from '@/components/debug/variable-watch-panel';
 import { EmptyState } from '@/components/shared/empty-state';
 import { TimelinePanel } from '@/components/timeline/timeline-panel';
@@ -48,6 +49,9 @@ export function BottomPanel() {
 				<TabsTrigger value="variables" className="h-6 text-xs">
 					Variables
 				</TabsTrigger>
+				<TabsTrigger value="callstack" className="h-6 text-xs">
+					Call Stack
+				</TabsTrigger>
 				<TabsTrigger value="dsl" className="h-6 text-xs">
 					DSL
 				</TabsTrigger>
@@ -63,6 +67,9 @@ export function BottomPanel() {
 			</TabsContent>
 			<TabsContent value="variables" className="mt-0 h-full">
 				<VariableWatchPanel />
+			</TabsContent>
+			<TabsContent value="callstack" className="mt-0 h-full">
+				<CallStackPanel />
 			</TabsContent>
 			<ScrollArea className="flex-1">
 				<TabsContent value="dsl" className="mt-0">


### PR DESCRIPTION
## Summary
- Adds `CallStackPanel` component displaying function call hierarchy during code execution
- Frames shown in reverse order (most recent on top) with expandable local variables and click-to-navigate
- Wired into the bottom panel as a new "Call Stack" tab

## Implementation Details
- **`src/components/debug/call-stack-panel.tsx`**: StackFrameItem with expand/collapse for local variables, click navigates via `setCurrentLine`, current frame highlighted with blue dot
- **`src/components/panels/bottom-panel.tsx`**: Added Call Stack tab
- **Navigation**: Clicking a frame calls `setCurrentLine(frame.lineNumber)` — the LineHighlightManager already watches this and reveals the line in Monaco during active execution

## Test plan
- [x] Empty state shows "No call stack" when no frames
- [x] Stack frames display function names and line numbers
- [x] Current (top) frame has visual indicator and "current" class
- [x] Frames shown in reverse order (most recent on top)
- [x] Click navigates to frame's line number via setCurrentLine
- [x] Expanded frames show local variables with formatted values
- [x] Empty local variables show "No local variables" message
- [x] Frame count displayed in toolbar (singular/plural)
- [x] ARIA live region for screen reader updates
- [x] Value formatting handles arrays, booleans, and strings
- [x] All 834 tests pass, Biome clean, TypeScript clean

Closes #35

🤖 Generated with [Claude Code](https://claude.com/claude-code)