### PR TITLE
feat: implement CPU Datapath composite with instruction cycle animation (#41)

### DIFF
--- a/src/lib/gsap/presets/cpu-datapath-presets.test.ts
+++ b/src/lib/gsap/presets/cpu-datapath-presets.test.ts
@@ -1,0 +1,184 @@
+/**
+ * Tests for CPU Datapath GSAP animation presets.
+ */
+
+import gsap from 'gsap';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+	cpuDataFlowHighlight,
+	cpuDecodeCycle,
+	cpuExecuteCycle,
+	cpuFetchCycle,
+	cpuFullCycle,
+	cpuMemoryAccess,
+	cpuWriteBack,
+} from './cpu-datapath-presets';
+
+interface MockComponent {
+	alpha: number;
+	_fillColor: number;
+}
+
+interface MockBus {
+	alpha: number;
+}
+
+function makeComponent(): MockComponent {
+	return { alpha: 1, _fillColor: 0x2a2a4a };
+}
+
+function makeBus(): MockBus {
+	return { alpha: 0.6 };
+}
+
+describe('CPU Datapath Animation Presets', () => {
+	beforeEach(() => {
+		gsap.ticker.lagSmoothing(0);
+	});
+
+	describe('cpuFetchCycle', () => {
+		it('returns a GSAP timeline', () => {
+			const tl = cpuFetchCycle(makeComponent(), makeComponent(), makeBus(), makeBus(), 0x3b82f6);
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+		});
+
+		it('has positive duration', () => {
+			const tl = cpuFetchCycle(makeComponent(), makeComponent(), makeBus(), makeBus(), 0x3b82f6);
+			expect(tl.duration()).toBeGreaterThan(0);
+		});
+
+		it('highlights PC during fetch', () => {
+			const pc = makeComponent();
+			const tl = cpuFetchCycle(pc, makeComponent(), makeBus(), makeBus(), 0x3b82f6);
+			tl.progress(0.2);
+			// PC should be highlighted at some point
+			expect(tl.duration()).toBeGreaterThan(0);
+		});
+	});
+
+	describe('cpuDecodeCycle', () => {
+		it('returns a GSAP timeline', () => {
+			const tl = cpuDecodeCycle(makeComponent(), makeComponent(), [makeBus(), makeBus()], 0x3b82f6);
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+		});
+
+		it('has positive duration', () => {
+			const tl = cpuDecodeCycle(makeComponent(), makeComponent(), [makeBus()], 0x3b82f6);
+			expect(tl.duration()).toBeGreaterThan(0);
+		});
+
+		it('handles empty control buses', () => {
+			const tl = cpuDecodeCycle(makeComponent(), makeComponent(), [], 0x3b82f6);
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+		});
+	});
+
+	describe('cpuExecuteCycle', () => {
+		it('returns a GSAP timeline', () => {
+			const tl = cpuExecuteCycle(makeComponent(), makeComponent(), makeBus(), 0x3b82f6);
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+		});
+
+		it('has positive duration', () => {
+			const tl = cpuExecuteCycle(makeComponent(), makeComponent(), makeBus(), 0x3b82f6);
+			expect(tl.duration()).toBeGreaterThan(0);
+		});
+	});
+
+	describe('cpuMemoryAccess', () => {
+		it('returns a GSAP timeline', () => {
+			const tl = cpuMemoryAccess(makeComponent(), makeComponent(), makeBus(), makeBus(), 0x3b82f6);
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+		});
+
+		it('has positive duration', () => {
+			const tl = cpuMemoryAccess(makeComponent(), makeComponent(), makeBus(), makeBus(), 0x3b82f6);
+			expect(tl.duration()).toBeGreaterThan(0);
+		});
+	});
+
+	describe('cpuWriteBack', () => {
+		it('returns a GSAP timeline', () => {
+			const tl = cpuWriteBack(makeComponent(), makeComponent(), makeBus(), 0x3b82f6);
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+		});
+
+		it('has positive duration', () => {
+			const tl = cpuWriteBack(makeComponent(), makeComponent(), makeBus(), 0x3b82f6);
+			expect(tl.duration()).toBeGreaterThan(0);
+		});
+	});
+
+	describe('cpuFullCycle', () => {
+		it('returns a GSAP timeline', () => {
+			const tl = cpuFullCycle(
+				makeComponent(), // pc
+				makeComponent(), // instrMem
+				makeComponent(), // controlUnit
+				makeComponent(), // registerFile
+				makeComponent(), // alu
+				makeComponent(), // dataMem
+				makeComponent(), // mux
+				{
+					pcAddr: makeBus(),
+					instrData: makeBus(),
+					controlSignals: [makeBus(), makeBus()],
+					regToAlu: makeBus(),
+					aluToMem: makeBus(),
+					memToMux: makeBus(),
+					muxToReg: makeBus(),
+				},
+				0x3b82f6,
+			);
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+		});
+
+		it('has duration greater than individual stages', () => {
+			const fetchTl = cpuFetchCycle(
+				makeComponent(),
+				makeComponent(),
+				makeBus(),
+				makeBus(),
+				0x3b82f6,
+			);
+			const fullTl = cpuFullCycle(
+				makeComponent(),
+				makeComponent(),
+				makeComponent(),
+				makeComponent(),
+				makeComponent(),
+				makeComponent(),
+				makeComponent(),
+				{
+					pcAddr: makeBus(),
+					instrData: makeBus(),
+					controlSignals: [],
+					regToAlu: makeBus(),
+					aluToMem: makeBus(),
+					memToMux: makeBus(),
+					muxToReg: makeBus(),
+				},
+				0x3b82f6,
+			);
+			expect(fullTl.duration()).toBeGreaterThan(fetchTl.duration());
+		});
+	});
+
+	describe('cpuDataFlowHighlight', () => {
+		it('returns a GSAP timeline', () => {
+			const tl = cpuDataFlowHighlight([makeBus(), makeBus(), makeBus()], 0x3b82f6);
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+		});
+
+		it('has positive duration with multiple buses', () => {
+			const tl = cpuDataFlowHighlight([makeBus(), makeBus()], 0x3b82f6);
+			expect(tl.duration()).toBeGreaterThan(0);
+		});
+
+		it('handles empty buses', () => {
+			const tl = cpuDataFlowHighlight([], 0x3b82f6);
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+			expect(tl.duration()).toBe(0);
+		});
+	});
+});

--- a/src/lib/gsap/presets/cpu-datapath-presets.ts
+++ b/src/lib/gsap/presets/cpu-datapath-presets.ts
@@ -1,0 +1,240 @@
+/**
+ * GSAP animation presets for CPU Datapath composite.
+ *
+ * Provides instruction cycle animations:
+ * - Fetch: PC → Instruction Memory → IR
+ * - Decode: Instruction → Control signals → Register read
+ * - Execute: ALU operation with operand flow
+ * - Memory: Data memory read/write
+ * - Write-back: Result → Register file
+ * - Data flow: Highlight path along buses
+ *
+ * Spec reference: Section 6.3.2 (CPU Datapath), Section 9.3 (Animation Presets)
+ */
+
+import gsap from 'gsap';
+
+interface AnimatableComponent {
+	alpha: number;
+	_fillColor: number;
+	scale?: { x: number; y: number };
+}
+
+interface AnimatableBus {
+	alpha: number;
+	_strokeColor?: number;
+}
+
+// ── Cycle Stage Animations ──
+
+/**
+ * Fetch cycle animation — highlights PC, then instruction memory, then instruction bus.
+ * Simulates: PC → addr bus → instruction memory → instruction register.
+ */
+export function cpuFetchCycle(
+	pc: AnimatableComponent,
+	instrMem: AnimatableComponent,
+	addrBus: AnimatableBus,
+	instrBus: AnimatableBus,
+	highlightColor: number,
+): gsap.core.Timeline {
+	const tl = gsap.timeline();
+	const pcOriginal = pc._fillColor;
+	const memOriginal = instrMem._fillColor;
+
+	// Step 1: Highlight PC
+	tl.to(pc, { _fillColor: highlightColor, duration: 0.2 }, 0);
+
+	// Step 2: Data flows along address bus
+	tl.to(addrBus, { alpha: 1, duration: 0.15 }, 0.2);
+
+	// Step 3: Instruction memory activates
+	tl.to(instrMem, { _fillColor: highlightColor, duration: 0.2 }, 0.35);
+
+	// Step 4: Instruction flows out
+	tl.to(instrBus, { alpha: 1, duration: 0.15 }, 0.55);
+
+	// Step 5: Revert colors
+	tl.to(pc, { _fillColor: pcOriginal, duration: 0.2 }, 0.8);
+	tl.to(instrMem, { _fillColor: memOriginal, duration: 0.2 }, 0.8);
+
+	return tl;
+}
+
+/**
+ * Decode cycle animation — control unit processes instruction and sends signals.
+ */
+export function cpuDecodeCycle(
+	controlUnit: AnimatableComponent,
+	registerFile: AnimatableComponent,
+	controlBuses: AnimatableBus[],
+	highlightColor: number,
+): gsap.core.Timeline {
+	const tl = gsap.timeline();
+	const ctrlOriginal = controlUnit._fillColor;
+	const regOriginal = registerFile._fillColor;
+
+	// Step 1: Control unit activates
+	tl.to(controlUnit, { _fillColor: highlightColor, duration: 0.2 }, 0);
+
+	// Step 2: Control signals propagate
+	for (let i = 0; i < controlBuses.length; i++) {
+		tl.to(controlBuses[i], { alpha: 1, duration: 0.1 }, 0.2 + i * 0.05);
+	}
+
+	// Step 3: Register file reads
+	tl.to(registerFile, { _fillColor: highlightColor, duration: 0.2 }, 0.4);
+
+	// Step 4: Revert
+	tl.to(controlUnit, { _fillColor: ctrlOriginal, duration: 0.2 }, 0.7);
+	tl.to(registerFile, { _fillColor: regOriginal, duration: 0.2 }, 0.7);
+
+	return tl;
+}
+
+/**
+ * Execute cycle animation — operands flow to ALU, result computed.
+ */
+export function cpuExecuteCycle(
+	registerFile: AnimatableComponent,
+	alu: AnimatableComponent,
+	dataBus: AnimatableBus,
+	highlightColor: number,
+): gsap.core.Timeline {
+	const tl = gsap.timeline();
+	const regOriginal = registerFile._fillColor;
+	const aluOriginal = alu._fillColor;
+
+	// Step 1: Register file sends operands
+	tl.to(registerFile, { _fillColor: highlightColor, duration: 0.2 }, 0);
+	tl.to(dataBus, { alpha: 1, duration: 0.15 }, 0.2);
+
+	// Step 2: ALU computes
+	tl.to(alu, { _fillColor: highlightColor, duration: 0.3 }, 0.35);
+
+	// Step 3: Revert
+	tl.to(registerFile, { _fillColor: regOriginal, duration: 0.2 }, 0.75);
+	tl.to(alu, { _fillColor: aluOriginal, duration: 0.2 }, 0.75);
+
+	return tl;
+}
+
+/**
+ * Memory access cycle — ALU result used as address, data memory read/write.
+ */
+export function cpuMemoryAccess(
+	alu: AnimatableComponent,
+	dataMem: AnimatableComponent,
+	addrBus: AnimatableBus,
+	dataBus: AnimatableBus,
+	highlightColor: number,
+): gsap.core.Timeline {
+	const tl = gsap.timeline();
+	const aluOriginal = alu._fillColor;
+	const memOriginal = dataMem._fillColor;
+
+	// Step 1: ALU sends address
+	tl.to(alu, { _fillColor: highlightColor, duration: 0.2 }, 0);
+	tl.to(addrBus, { alpha: 1, duration: 0.15 }, 0.2);
+
+	// Step 2: Data memory activates
+	tl.to(dataMem, { _fillColor: highlightColor, duration: 0.2 }, 0.35);
+
+	// Step 3: Data flows out
+	tl.to(dataBus, { alpha: 1, duration: 0.15 }, 0.55);
+
+	// Step 4: Revert
+	tl.to(alu, { _fillColor: aluOriginal, duration: 0.2 }, 0.8);
+	tl.to(dataMem, { _fillColor: memOriginal, duration: 0.2 }, 0.8);
+
+	return tl;
+}
+
+/**
+ * Write-back cycle — result flows through MUX to register file.
+ */
+export function cpuWriteBack(
+	mux: AnimatableComponent,
+	registerFile: AnimatableComponent,
+	dataBus: AnimatableBus,
+	highlightColor: number,
+): gsap.core.Timeline {
+	const tl = gsap.timeline();
+	const muxOriginal = mux._fillColor;
+	const regOriginal = registerFile._fillColor;
+
+	// Step 1: MUX selects result
+	tl.to(mux, { _fillColor: highlightColor, duration: 0.2 }, 0);
+
+	// Step 2: Data flows to register file
+	tl.to(dataBus, { alpha: 1, duration: 0.15 }, 0.2);
+
+	// Step 3: Register file writes
+	tl.to(registerFile, { _fillColor: highlightColor, duration: 0.2 }, 0.35);
+
+	// Step 4: Revert
+	tl.to(mux, { _fillColor: muxOriginal, duration: 0.2 }, 0.65);
+	tl.to(registerFile, { _fillColor: regOriginal, duration: 0.2 }, 0.65);
+
+	return tl;
+}
+
+/**
+ * Full instruction cycle — chains all 5 stages sequentially.
+ */
+export function cpuFullCycle(
+	pc: AnimatableComponent,
+	instrMem: AnimatableComponent,
+	controlUnit: AnimatableComponent,
+	registerFile: AnimatableComponent,
+	alu: AnimatableComponent,
+	dataMem: AnimatableComponent,
+	mux: AnimatableComponent,
+	buses: {
+		pcAddr: AnimatableBus;
+		instrData: AnimatableBus;
+		controlSignals: AnimatableBus[];
+		regToAlu: AnimatableBus;
+		aluToMem: AnimatableBus;
+		memToMux: AnimatableBus;
+		muxToReg: AnimatableBus;
+	},
+	highlightColor: number,
+): gsap.core.Timeline {
+	const tl = gsap.timeline();
+
+	// Fetch
+	tl.add(cpuFetchCycle(pc, instrMem, buses.pcAddr, buses.instrData, highlightColor));
+
+	// Decode
+	tl.add(cpuDecodeCycle(controlUnit, registerFile, buses.controlSignals, highlightColor), '>-0.1');
+
+	// Execute
+	tl.add(cpuExecuteCycle(registerFile, alu, buses.regToAlu, highlightColor), '>-0.1');
+
+	// Memory
+	tl.add(cpuMemoryAccess(alu, dataMem, buses.aluToMem, buses.memToMux, highlightColor), '>-0.1');
+
+	// Write-back
+	tl.add(cpuWriteBack(mux, registerFile, buses.muxToReg, highlightColor), '>-0.1');
+
+	return tl;
+}
+
+/**
+ * Data flow highlight — pulses a sequence of buses to show data path.
+ */
+export function cpuDataFlowHighlight(
+	buses: AnimatableBus[],
+	highlightColor: number,
+): gsap.core.Timeline {
+	const tl = gsap.timeline();
+
+	for (let i = 0; i < buses.length; i++) {
+		const bus = buses[i];
+		tl.to(bus, { alpha: 1, duration: 0.15, ease: 'power2.out' }, i * 0.12);
+		tl.to(bus, { alpha: 0.6, duration: 0.2, ease: 'power1.in' }, i * 0.12 + 0.25);
+	}
+
+	return tl;
+}

--- a/src/lib/pixi/renderers/cpu-datapath-renderer.test.ts
+++ b/src/lib/pixi/renderers/cpu-datapath-renderer.test.ts
@@ -1,0 +1,215 @@
+/**
+ * Tests for CpuDatapathRenderer — CPU Datapath composite visualization.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { JsonValue, SceneElement } from '@/types';
+import { CpuDatapathRenderer } from './cpu-datapath-renderer';
+import { DEFAULT_ELEMENT_STYLE } from './shared';
+
+function createMockPixi() {
+	function MockContainer(this: Record<string, unknown>) {
+		const children: unknown[] = [];
+		this.addChild = vi.fn((...args: unknown[]) => children.push(...args));
+		this.removeChildren = vi.fn();
+		this.destroy = vi.fn();
+		this.position = { set: vi.fn(), x: 0, y: 0 };
+		this.alpha = 1;
+		this.angle = 0;
+		this.visible = true;
+		this.label = '';
+		this.cullable = false;
+		this.children = children;
+	}
+
+	function MockGraphics(this: Record<string, unknown>) {
+		this.clear = vi.fn().mockReturnThis();
+		this.rect = vi.fn().mockReturnThis();
+		this.roundRect = vi.fn().mockReturnThis();
+		this.circle = vi.fn().mockReturnThis();
+		this.fill = vi.fn().mockReturnThis();
+		this.stroke = vi.fn().mockReturnThis();
+		this.moveTo = vi.fn().mockReturnThis();
+		this.lineTo = vi.fn().mockReturnThis();
+		this.bezierCurveTo = vi.fn().mockReturnThis();
+		this.poly = vi.fn().mockReturnThis();
+		this.closePath = vi.fn().mockReturnThis();
+		this.destroy = vi.fn();
+	}
+
+	function MockText(this: Record<string, unknown>, opts: { text: string; style: unknown }) {
+		this.text = opts.text;
+		this.style = opts.style;
+		this.anchor = { set: vi.fn() };
+		this.position = { set: vi.fn() };
+		this.visible = true;
+		this.destroy = vi.fn();
+	}
+
+	function MockTextStyle(_opts: Record<string, unknown>) {
+		return { ..._opts };
+	}
+
+	return {
+		Container: vi.fn().mockImplementation(MockContainer),
+		Graphics: vi.fn().mockImplementation(MockGraphics),
+		Text: vi.fn().mockImplementation(MockText),
+		TextStyle: vi.fn().mockImplementation(MockTextStyle),
+	};
+}
+
+function makeElement(metadata: Record<string, JsonValue> = {}): SceneElement {
+	return {
+		id: 'datapath-1',
+		type: 'register',
+		position: { x: 0, y: 0 },
+		size: { width: 750, height: 250 },
+		rotation: 0,
+		opacity: 1,
+		visible: true,
+		locked: false,
+		style: DEFAULT_ELEMENT_STYLE,
+		metadata,
+	};
+}
+
+describe('CpuDatapathRenderer', () => {
+	let renderer: CpuDatapathRenderer;
+
+	beforeEach(() => {
+		const pixi = createMockPixi();
+		renderer = new CpuDatapathRenderer(pixi as never);
+	});
+
+	describe('render', () => {
+		it('creates a container with default components', () => {
+			const element = makeElement();
+			const container = renderer.render(element);
+
+			// Should create Graphics and Text for each component + bus
+			expect(container).toBeDefined();
+			expect(container.children.length).toBeGreaterThan(0);
+		});
+
+		it('renders all 7 default components', () => {
+			const element = makeElement();
+			renderer.render(element);
+
+			const containers = renderer.getComponentContainers('datapath-1');
+			expect(containers).toBeDefined();
+			expect(containers?.size).toBe(7);
+			expect(containers?.has('pc')).toBe(true);
+			expect(containers?.has('imem')).toBe(true);
+			expect(containers?.has('regfile')).toBe(true);
+			expect(containers?.has('alu')).toBe(true);
+			expect(containers?.has('dmem')).toBe(true);
+			expect(containers?.has('ctrl')).toBe(true);
+			expect(containers?.has('mux-wb')).toBe(true);
+		});
+
+		it('renders bus graphics', () => {
+			const element = makeElement();
+			renderer.render(element);
+
+			const buses = renderer.getBusGraphics('datapath-1');
+			expect(buses).toBeDefined();
+			expect(buses?.size).toBeGreaterThan(0);
+			expect(buses?.has('bus-pc-imem')).toBe(true);
+			expect(buses?.has('bus-reg-alu')).toBe(true);
+		});
+
+		it('renders with custom components', () => {
+			const element = makeElement({
+				components: [
+					{ type: 'pc', id: 'my-pc', label: 'PC', x: 0, y: 0, width: 50, height: 40 },
+					{ type: 'alu', id: 'my-alu', label: 'ALU', x: 100, y: 0, width: 60, height: 70 },
+				],
+				buses: [],
+			});
+
+			renderer.render(element);
+			const containers = renderer.getComponentContainers('datapath-1');
+			expect(containers?.size).toBe(2);
+			expect(containers?.has('my-pc')).toBe(true);
+			expect(containers?.has('my-alu')).toBe(true);
+		});
+
+		it('renders clock cycle counter when > 0', () => {
+			const pixi = createMockPixi();
+			const rend = new CpuDatapathRenderer(pixi as never);
+			const element = makeElement({ clockCycle: 5 });
+
+			rend.render(element);
+
+			// Verify Text was called with "Cycle: 5"
+			const textCalls = pixi.Text.mock.calls;
+			const cycleText = textCalls.find(
+				(c: unknown[]) => (c[0] as { text: string }).text === 'Cycle: 5',
+			);
+			expect(cycleText).toBeDefined();
+		});
+
+		it('does not render clock cycle counter when 0', () => {
+			const pixi = createMockPixi();
+			const rend = new CpuDatapathRenderer(pixi as never);
+			const element = makeElement({ clockCycle: 0 });
+
+			rend.render(element);
+
+			const textCalls = pixi.Text.mock.calls;
+			const cycleText = textCalls.find((c: unknown[]) =>
+				(c[0] as { text: string }).text.startsWith('Cycle:'),
+			);
+			expect(cycleText).toBeUndefined();
+		});
+
+		it('shows ALU operation when specified', () => {
+			const pixi = createMockPixi();
+			const rend = new CpuDatapathRenderer(pixi as never);
+			const element = makeElement({ aluOp: 'ADD' });
+
+			rend.render(element);
+
+			const textCalls = pixi.Text.mock.calls;
+			const aluText = textCalls.find((c: unknown[]) =>
+				(c[0] as { text: string }).text.includes('ADD'),
+			);
+			expect(aluText).toBeDefined();
+		});
+
+		it('highlights specified components', () => {
+			const pixi = createMockPixi();
+			const rend = new CpuDatapathRenderer(pixi as never);
+			const element = makeElement({
+				highlightedComponents: ['pc', 'alu'],
+			});
+
+			const container = rend.render(element);
+			// Should render without errors — visual highlight is color-based
+			expect(container).toBeDefined();
+		});
+
+		it('highlights specified buses', () => {
+			const pixi = createMockPixi();
+			const rend = new CpuDatapathRenderer(pixi as never);
+			const element = makeElement({
+				highlightedBuses: ['bus-pc-imem', 'bus-reg-alu'],
+			});
+
+			const container = rend.render(element);
+			expect(container).toBeDefined();
+		});
+	});
+
+	describe('getComponentContainers', () => {
+		it('returns undefined for unknown element', () => {
+			expect(renderer.getComponentContainers('nonexistent')).toBeUndefined();
+		});
+	});
+
+	describe('getBusGraphics', () => {
+		it('returns undefined for unknown element', () => {
+			expect(renderer.getBusGraphics('nonexistent')).toBeUndefined();
+		});
+	});
+});

--- a/src/lib/pixi/renderers/cpu-datapath-renderer.ts
+++ b/src/lib/pixi/renderers/cpu-datapath-renderer.ts
@@ -1,0 +1,391 @@
+/**
+ * Renderer for CPU Datapath composite elements.
+ *
+ * Renders a simplified single-cycle CPU datapath with:
+ * - Register file with read/write ports
+ * - ALU unit with operation display
+ * - MUX components with select signal
+ * - Control unit with signal outputs
+ * - Program counter
+ * - Instruction memory and data memory blocks
+ * - Data/address/control buses connecting components
+ *
+ * Component containers are stored for GSAP animation targeting.
+ *
+ * Spec reference: Section 6.3.2 (CPU Datapath)
+ */
+
+import type { SceneElement } from '@/types';
+import { hexToPixiColor } from './shared';
+
+// ── Pixi.js DI interfaces ──
+
+interface PixiContainer {
+	addChild(...children: unknown[]): void;
+	removeChildren(): void;
+	destroy(options?: { children: boolean }): void;
+	position: { set(x: number, y: number): void; x: number; y: number };
+	alpha: number;
+	angle: number;
+	visible: boolean;
+	label: string;
+	cullable: boolean;
+	children: unknown[];
+}
+
+interface PixiGraphics {
+	clear(): PixiGraphics;
+	rect(x: number, y: number, w: number, h: number): PixiGraphics;
+	roundRect(x: number, y: number, w: number, h: number, r: number): PixiGraphics;
+	circle(x: number, y: number, r: number): PixiGraphics;
+	fill(opts: { color: number; alpha?: number } | number): PixiGraphics;
+	stroke(opts: { width: number; color: number; alpha?: number }): PixiGraphics;
+	moveTo(x: number, y: number): PixiGraphics;
+	lineTo(x: number, y: number): PixiGraphics;
+	bezierCurveTo(
+		cp1x: number,
+		cp1y: number,
+		cp2x: number,
+		cp2y: number,
+		x: number,
+		y: number,
+	): PixiGraphics;
+	poly(points: number[]): PixiGraphics;
+	closePath(): PixiGraphics;
+	destroy(): void;
+}
+
+interface PixiText {
+	text: string;
+	style: Record<string, unknown>;
+	anchor: { set(x: number, y: number): void };
+	position: { set(x: number, y: number): void };
+	visible: boolean;
+	destroy(): void;
+}
+
+interface PixiModule {
+	Container: new () => PixiContainer;
+	Graphics: new () => PixiGraphics;
+	Text: new (opts: { text: string; style: unknown }) => PixiText;
+	TextStyle: new (opts: Record<string, unknown>) => Record<string, unknown>;
+}
+
+// ── Datapath Component Types ──
+
+export type DatapathComponentType =
+	| 'pc'
+	| 'instructionMemory'
+	| 'registerFile'
+	| 'alu'
+	| 'dataMemory'
+	| 'controlUnit'
+	| 'mux';
+
+export interface DatapathComponent {
+	type: DatapathComponentType;
+	id: string;
+	label: string;
+	x: number;
+	y: number;
+	width: number;
+	height: number;
+}
+
+export interface DatapathBus {
+	id: string;
+	fromId: string;
+	toId: string;
+	label?: string;
+	type: 'data' | 'address' | 'control';
+}
+
+/** Internal layout positions for each component. */
+interface ComponentLayout {
+	x: number;
+	y: number;
+	w: number;
+	h: number;
+}
+
+// ── Default component layout ──
+
+const DEFAULT_COMPONENTS: DatapathComponent[] = [
+	{ type: 'pc', id: 'pc', label: 'PC', x: 0, y: 120, width: 60, height: 50 },
+	{
+		type: 'instructionMemory',
+		id: 'imem',
+		label: 'Instruction\nMemory',
+		x: 100,
+		y: 100,
+		width: 80,
+		height: 90,
+	},
+	{
+		type: 'registerFile',
+		id: 'regfile',
+		label: 'Registers',
+		x: 240,
+		y: 80,
+		width: 90,
+		height: 120,
+	},
+	{ type: 'alu', id: 'alu', label: 'ALU', x: 400, y: 100, width: 70, height: 80 },
+	{
+		type: 'dataMemory',
+		id: 'dmem',
+		label: 'Data\nMemory',
+		x: 520,
+		y: 100,
+		width: 80,
+		height: 90,
+	},
+	{
+		type: 'controlUnit',
+		id: 'ctrl',
+		label: 'Control',
+		x: 240,
+		y: 0,
+		width: 90,
+		height: 50,
+	},
+	{ type: 'mux', id: 'mux-wb', label: 'MUX', x: 640, y: 120, width: 40, height: 50 },
+];
+
+const DEFAULT_BUSES: DatapathBus[] = [
+	{ id: 'bus-pc-imem', fromId: 'pc', toId: 'imem', type: 'address', label: 'addr' },
+	{ id: 'bus-imem-ctrl', fromId: 'imem', toId: 'ctrl', type: 'data', label: 'instr' },
+	{ id: 'bus-imem-reg', fromId: 'imem', toId: 'regfile', type: 'data' },
+	{ id: 'bus-reg-alu', fromId: 'regfile', toId: 'alu', type: 'data' },
+	{ id: 'bus-alu-dmem', fromId: 'alu', toId: 'dmem', type: 'address' },
+	{ id: 'bus-dmem-mux', fromId: 'dmem', toId: 'mux-wb', type: 'data' },
+	{ id: 'bus-alu-mux', fromId: 'alu', toId: 'mux-wb', type: 'data' },
+	{ id: 'bus-mux-reg', fromId: 'mux-wb', toId: 'regfile', type: 'data', label: 'WB' },
+	{ id: 'bus-ctrl-reg', fromId: 'ctrl', toId: 'regfile', type: 'control' },
+	{ id: 'bus-ctrl-alu', fromId: 'ctrl', toId: 'alu', type: 'control' },
+	{ id: 'bus-ctrl-dmem', fromId: 'ctrl', toId: 'dmem', type: 'control' },
+];
+
+// ── Bus Colors ──
+
+const BUS_COLORS: Record<DatapathBus['type'], string> = {
+	data: '#22d3ee',
+	address: '#a78bfa',
+	control: '#f472b6',
+};
+
+/**
+ * Renderer for CPU Datapath composite elements.
+ */
+export class CpuDatapathRenderer {
+	private pixi: PixiModule;
+	private componentContainers: Record<string, Map<string, PixiContainer>> = {};
+	private busGraphics: Record<string, Map<string, PixiGraphics>> = {};
+
+	constructor(pixi: PixiModule) {
+		this.pixi = pixi;
+	}
+
+	/**
+	 * Render a CPU datapath element.
+	 */
+	render(element: SceneElement): PixiContainer {
+		const container = new this.pixi.Container();
+		const { style, metadata } = element;
+
+		const components =
+			(metadata.components as unknown as DatapathComponent[]) ?? DEFAULT_COMPONENTS;
+		const buses = (metadata.buses as unknown as DatapathBus[]) ?? DEFAULT_BUSES;
+		const highlightedComponents = (metadata.highlightedComponents as string[]) ?? [];
+		const highlightedBuses = (metadata.highlightedBuses as string[]) ?? [];
+		const highlightColor = (metadata.highlightColor as string) ?? '#3b82f6';
+		const clockCycle = (metadata.clockCycle as number) ?? 0;
+		const aluOp = (metadata.aluOp as string) ?? '';
+
+		const fillColor = hexToPixiColor(style.fill);
+		const strokeColor = hexToPixiColor(style.stroke);
+		const highlightPixi = hexToPixiColor(highlightColor);
+
+		// Build component position lookup
+		const componentMap = new Map<string, ComponentLayout>();
+		for (const comp of components) {
+			componentMap.set(comp.id, {
+				x: comp.x,
+				y: comp.y,
+				w: comp.width,
+				h: comp.height,
+			});
+		}
+
+		const compContainers = new Map<string, PixiContainer>();
+		const busGfx = new Map<string, PixiGraphics>();
+
+		// Pass 1: Draw buses (behind components)
+		for (const bus of buses) {
+			const fromLayout = componentMap.get(bus.fromId);
+			const toLayout = componentMap.get(bus.toId);
+			if (!fromLayout || !toLayout) continue;
+
+			const isHighlighted = highlightedBuses.includes(bus.id);
+			const busColor = hexToPixiColor(BUS_COLORS[bus.type]);
+
+			const g = new this.pixi.Graphics();
+			const fromX = fromLayout.x + fromLayout.w;
+			const fromY = fromLayout.y + fromLayout.h / 2;
+			const toX = toLayout.x;
+			const toY = toLayout.y + toLayout.h / 2;
+
+			g.moveTo(fromX, fromY);
+			g.lineTo(toX, toY);
+			g.stroke({
+				width: isHighlighted ? 3 : 1.5,
+				color: isHighlighted ? highlightPixi : busColor,
+				alpha: isHighlighted ? 1 : 0.6,
+			});
+			container.addChild(g);
+
+			// Bus label
+			if (bus.label) {
+				const midX = (fromX + toX) / 2;
+				const midY = (fromY + toY) / 2;
+				const labelStyle = new this.pixi.TextStyle({
+					fontSize: 9,
+					fontFamily: style.fontFamily,
+					fontWeight: '400',
+					fill: busColor,
+				});
+				const labelText = new this.pixi.Text({ text: bus.label, style: labelStyle });
+				labelText.anchor.set(0.5, 1);
+				labelText.position.set(midX, midY - 3);
+				container.addChild(labelText);
+			}
+
+			busGfx.set(bus.id, g);
+		}
+
+		// Pass 2: Draw components
+		for (const comp of components) {
+			const isHighlighted = highlightedComponents.includes(comp.id);
+
+			const g = new this.pixi.Graphics();
+
+			if (comp.type === 'alu') {
+				// ALU gets a trapezoid shape
+				this.drawAluShape(
+					g,
+					comp,
+					isHighlighted ? highlightPixi : fillColor,
+					strokeColor,
+					style.strokeWidth,
+				);
+			} else if (comp.type === 'mux') {
+				// MUX gets a narrower shape
+				this.drawMuxShape(
+					g,
+					comp,
+					isHighlighted ? highlightPixi : fillColor,
+					strokeColor,
+					style.strokeWidth,
+				);
+			} else {
+				// Standard rectangular component
+				g.roundRect(comp.x, comp.y, comp.width, comp.height, 4);
+				g.fill({ color: isHighlighted ? highlightPixi : fillColor });
+				g.stroke({ width: style.strokeWidth, color: strokeColor });
+			}
+			container.addChild(g);
+
+			// Component label
+			const labelStyle = new this.pixi.TextStyle({
+				fontSize: comp.type === 'pc' || comp.type === 'mux' ? 10 : 11,
+				fontFamily: style.fontFamily,
+				fontWeight: '600',
+				fill: hexToPixiColor(style.textColor),
+			});
+			const labelText = new this.pixi.Text({
+				text: comp.type === 'alu' && aluOp ? `ALU\n${aluOp}` : comp.label,
+				style: labelStyle,
+			});
+			labelText.anchor.set(0.5, 0.5);
+			labelText.position.set(comp.x + comp.width / 2, comp.y + comp.height / 2);
+			container.addChild(labelText);
+
+			compContainers.set(comp.id, container);
+		}
+
+		// Pass 3: Clock cycle counter
+		if (clockCycle > 0) {
+			const clockStyle = new this.pixi.TextStyle({
+				fontSize: 11,
+				fontFamily: style.fontFamily,
+				fontWeight: '600',
+				fill: hexToPixiColor('#fbbf24'),
+			});
+			const clockText = new this.pixi.Text({
+				text: `Cycle: ${clockCycle}`,
+				style: clockStyle,
+			});
+			clockText.anchor.set(0, 0);
+			clockText.position.set(0, -20);
+			container.addChild(clockText);
+		}
+
+		this.componentContainers[element.id] = compContainers;
+		this.busGraphics[element.id] = busGfx;
+		return container;
+	}
+
+	/**
+	 * Get component containers for animation targeting.
+	 */
+	getComponentContainers(elementId: string): Map<string, PixiContainer> | undefined {
+		return this.componentContainers[elementId];
+	}
+
+	/**
+	 * Get bus graphics for animation targeting.
+	 */
+	getBusGraphics(elementId: string): Map<string, PixiGraphics> | undefined {
+		return this.busGraphics[elementId];
+	}
+
+	// ── Shape drawing helpers ──
+
+	private drawAluShape(
+		g: PixiGraphics,
+		comp: DatapathComponent,
+		fillColor: number,
+		strokeColor: number,
+		strokeWidth: number,
+	): void {
+		const { x, y, width: w, height: h } = comp;
+		// Trapezoid: wider at top, narrower at bottom
+		const inset = w * 0.2;
+		g.moveTo(x, y);
+		g.lineTo(x + w, y);
+		g.lineTo(x + w - inset, y + h);
+		g.lineTo(x + inset, y + h);
+		g.closePath();
+		g.fill({ color: fillColor });
+		g.stroke({ width: strokeWidth, color: strokeColor });
+	}
+
+	private drawMuxShape(
+		g: PixiGraphics,
+		comp: DatapathComponent,
+		fillColor: number,
+		strokeColor: number,
+		strokeWidth: number,
+	): void {
+		const { x, y, width: w, height: h } = comp;
+		// Trapezoid: narrower at top, wider at bottom
+		const inset = w * 0.15;
+		g.moveTo(x + inset, y);
+		g.lineTo(x + w - inset, y);
+		g.lineTo(x + w, y + h);
+		g.lineTo(x, y + h);
+		g.closePath();
+		g.fill({ color: fillColor });
+		g.stroke({ width: strokeWidth, color: strokeColor });
+	}
+}


### PR DESCRIPTION
## Summary

- **CPU Datapath renderer** with 7 default components (PC, instruction memory, register file, ALU, data memory, control unit, write-back MUX) with customizable positions and sizes
- **11 data/address/control buses** connecting components with color-coded visualization (cyan=data, purple=address, pink=control)
- **GSAP animation presets** for all 5 instruction cycle stages: fetch (PC→IMEM→IR), decode (control signals→register read), execute (operands→ALU), memory access (ALU→DMEM), and write-back (MUX→registers)
- **Full instruction cycle** animation chaining all stages sequentially with slight overlap for fluid flow
- Clock cycle counter, ALU operation display, and component/bus highlighting

## Test plan

- [x] 11 renderer tests covering default components, buses, custom components, clock cycle, ALU op, highlighting
- [x] 17 GSAP preset tests covering all 5 cycle stages, full cycle, data flow highlight, edge cases
- [x] All 1028 tests pass (`pnpm vitest run`)
- [x] TypeScript strict mode passes (`pnpm tsc --noEmit`)
- [x] Biome lint/format passes (`pnpm biome check --write .`)

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)