### PR TITLE
feat: implement AVL Tree composite with rotation animations (#45)

### DIFF
--- a/src/lib/gsap/presets/avl-tree-presets.test.ts
+++ b/src/lib/gsap/presets/avl-tree-presets.test.ts
@@ -1,0 +1,201 @@
+/**
+ * Tests for AVL Tree GSAP animation presets.
+ */
+
+import gsap from 'gsap';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+	avlHeightUpdate,
+	avlInsertRebalance,
+	avlLeftRightRotation,
+	avlLeftRotation,
+	avlRightLeftRotation,
+	avlRightRotation,
+} from './avl-tree-presets';
+
+interface MockNode {
+	alpha: number;
+	_fillColor: number;
+	position: { x: number; y: number };
+}
+
+function makeNode(): MockNode {
+	return { alpha: 0.8, _fillColor: 0x2a2a4a, position: { x: 100, y: 100 } };
+}
+
+describe('AVL Tree Animation Presets', () => {
+	beforeEach(() => {
+		gsap.ticker.lagSmoothing(0);
+	});
+
+	describe('avlInsertRebalance', () => {
+		it('returns a GSAP timeline', () => {
+			const tl = avlInsertRebalance([makeNode(), makeNode()], makeNode(), 0x4ade80, 0x3b82f6);
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+		});
+
+		it('has positive duration', () => {
+			const tl = avlInsertRebalance([makeNode()], makeNode(), 0x4ade80, 0x3b82f6);
+			expect(tl.duration()).toBeGreaterThan(0);
+		});
+
+		it('duration scales with path length', () => {
+			const short = avlInsertRebalance([makeNode()], makeNode(), 0x4ade80, 0x3b82f6);
+			const long = avlInsertRebalance(
+				[makeNode(), makeNode(), makeNode(), makeNode()],
+				makeNode(),
+				0x4ade80,
+				0x3b82f6,
+			);
+			expect(long.duration()).toBeGreaterThan(short.duration());
+		});
+
+		it('handles empty path', () => {
+			const tl = avlInsertRebalance([], makeNode(), 0x4ade80, 0x3b82f6);
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+			expect(tl.duration()).toBeGreaterThan(0);
+		});
+	});
+
+	describe('avlLeftRotation', () => {
+		it('returns a GSAP timeline', () => {
+			const tl = avlLeftRotation(
+				makeNode(),
+				makeNode(),
+				{ x: 80, y: 160 },
+				{ x: 100, y: 100 },
+				0xf97316,
+			);
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+		});
+
+		it('has positive duration', () => {
+			const tl = avlLeftRotation(
+				makeNode(),
+				makeNode(),
+				{ x: 80, y: 160 },
+				{ x: 100, y: 100 },
+				0xf97316,
+			);
+			expect(tl.duration()).toBeGreaterThan(0);
+		});
+	});
+
+	describe('avlRightRotation', () => {
+		it('returns a GSAP timeline', () => {
+			const tl = avlRightRotation(
+				makeNode(),
+				makeNode(),
+				{ x: 120, y: 160 },
+				{ x: 100, y: 100 },
+				0xf97316,
+			);
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+		});
+
+		it('has positive duration', () => {
+			const tl = avlRightRotation(
+				makeNode(),
+				makeNode(),
+				{ x: 120, y: 160 },
+				{ x: 100, y: 100 },
+				0xf97316,
+			);
+			expect(tl.duration()).toBeGreaterThan(0);
+		});
+	});
+
+	describe('avlLeftRightRotation', () => {
+		it('returns a GSAP timeline', () => {
+			const tl = avlLeftRightRotation(
+				makeNode(),
+				makeNode(),
+				makeNode(),
+				{
+					rootTarget: { x: 120, y: 160 },
+					leftTarget: { x: 80, y: 160 },
+					lrTarget: { x: 100, y: 100 },
+				},
+				0xf97316,
+			);
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+		});
+
+		it('has longer duration than single rotation', () => {
+			const single = avlLeftRotation(
+				makeNode(),
+				makeNode(),
+				{ x: 80, y: 160 },
+				{ x: 100, y: 100 },
+				0xf97316,
+			);
+			const double = avlLeftRightRotation(
+				makeNode(),
+				makeNode(),
+				makeNode(),
+				{
+					rootTarget: { x: 120, y: 160 },
+					leftTarget: { x: 80, y: 160 },
+					lrTarget: { x: 100, y: 100 },
+				},
+				0xf97316,
+			);
+			expect(double.duration()).toBeGreaterThan(single.duration());
+		});
+	});
+
+	describe('avlRightLeftRotation', () => {
+		it('returns a GSAP timeline', () => {
+			const tl = avlRightLeftRotation(
+				makeNode(),
+				makeNode(),
+				makeNode(),
+				{
+					rootTarget: { x: 80, y: 160 },
+					rightTarget: { x: 120, y: 160 },
+					rlTarget: { x: 100, y: 100 },
+				},
+				0xf97316,
+			);
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+		});
+
+		it('has positive duration', () => {
+			const tl = avlRightLeftRotation(
+				makeNode(),
+				makeNode(),
+				makeNode(),
+				{
+					rootTarget: { x: 80, y: 160 },
+					rightTarget: { x: 120, y: 160 },
+					rlTarget: { x: 100, y: 100 },
+				},
+				0xf97316,
+			);
+			expect(tl.duration()).toBeGreaterThan(0);
+		});
+	});
+
+	describe('avlHeightUpdate', () => {
+		it('returns a GSAP timeline', () => {
+			const tl = avlHeightUpdate([makeNode(), makeNode(), makeNode()], 0xfbbf24);
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+		});
+
+		it('has positive duration', () => {
+			const tl = avlHeightUpdate([makeNode(), makeNode()], 0xfbbf24);
+			expect(tl.duration()).toBeGreaterThan(0);
+		});
+
+		it('has zero duration with empty nodes', () => {
+			const tl = avlHeightUpdate([], 0xfbbf24);
+			expect(tl.duration()).toBe(0);
+		});
+
+		it('duration scales with node count', () => {
+			const short = avlHeightUpdate([makeNode()], 0xfbbf24);
+			const long = avlHeightUpdate([makeNode(), makeNode(), makeNode(), makeNode()], 0xfbbf24);
+			expect(long.duration()).toBeGreaterThan(short.duration());
+		});
+	});
+});

--- a/src/lib/gsap/presets/avl-tree-presets.ts
+++ b/src/lib/gsap/presets/avl-tree-presets.ts
@@ -1,0 +1,240 @@
+/**
+ * GSAP animation presets for AVL Tree composite.
+ *
+ * Provides AVL-specific animations:
+ * - Insert with rebalance check
+ * - Left rotation / Right rotation
+ * - Left-Right (double) / Right-Left (double) rotation
+ * - Height update propagation
+ *
+ * Spec reference: Section 6.3.1 (AVL Tree), Section 9.3 (Animation Presets)
+ */
+
+import gsap from 'gsap';
+
+interface AnimatableNode {
+	alpha: number;
+	_fillColor?: number;
+	position?: { x: number; y: number };
+}
+
+// ── Insert with Rebalance ──
+
+/**
+ * Insert with rebalance — highlights the insertion path, then
+ * checks balance factors up the tree, triggering rotation if needed.
+ */
+export function avlInsertRebalance(
+	pathNodes: AnimatableNode[],
+	insertedNode: AnimatableNode,
+	insertColor: number,
+	checkColor: number,
+): gsap.core.Timeline {
+	const tl = gsap.timeline();
+
+	// Step 1: Highlight insertion path
+	for (let i = 0; i < pathNodes.length; i++) {
+		const node = pathNodes[i];
+		const originalColor = node._fillColor ?? 0x2a2a4a;
+		tl.to(node, { _fillColor: checkColor, alpha: 1, duration: 0.12 }, i * 0.1);
+		tl.to(node, { _fillColor: originalColor, alpha: 0.8, duration: 0.1 }, i * 0.1 + 0.15);
+	}
+
+	// Step 2: Insert node (fade in)
+	const pathDuration = pathNodes.length * 0.1 + 0.25;
+	tl.fromTo(
+		insertedNode,
+		{ alpha: 0, _fillColor: insertColor },
+		{ alpha: 1, duration: 0.2, ease: 'back.out' },
+		pathDuration,
+	);
+
+	// Step 3: Balance check back up
+	for (let i = pathNodes.length - 1; i >= 0; i--) {
+		const node = pathNodes[i];
+		const reverseIdx = pathNodes.length - 1 - i;
+		tl.to(
+			node,
+			{ _fillColor: checkColor, alpha: 1, duration: 0.1 },
+			pathDuration + 0.3 + reverseIdx * 0.08,
+		);
+		tl.to(node, { alpha: 0.8, duration: 0.08 }, pathDuration + 0.3 + reverseIdx * 0.08 + 0.12);
+	}
+
+	return tl;
+}
+
+// ── Rotations ──
+
+/**
+ * Left rotation animation — node A moves down-left, node B moves up
+ * to replace A's position. B's left subtree becomes A's right child.
+ */
+export function avlLeftRotation(
+	pivotNode: AnimatableNode,
+	childNode: AnimatableNode,
+	pivotTarget: { x: number; y: number },
+	childTarget: { x: number; y: number },
+	rotationColor: number,
+): gsap.core.Timeline {
+	const tl = gsap.timeline();
+
+	// Step 1: Highlight nodes involved
+	tl.to(pivotNode, { _fillColor: rotationColor, alpha: 1, duration: 0.15 }, 0);
+	tl.to(childNode, { _fillColor: rotationColor, alpha: 1, duration: 0.15 }, 0);
+
+	// Step 2: Animate position swap
+	if (pivotNode.position) {
+		tl.to(
+			pivotNode.position,
+			{ x: pivotTarget.x, y: pivotTarget.y, duration: 0.4, ease: 'power2.inOut' },
+			0.2,
+		);
+	}
+	if (childNode.position) {
+		tl.to(
+			childNode.position,
+			{ x: childTarget.x, y: childTarget.y, duration: 0.4, ease: 'power2.inOut' },
+			0.2,
+		);
+	}
+
+	// Step 3: Revert highlight
+	tl.to(pivotNode, { alpha: 0.8, duration: 0.15 }, 0.7);
+	tl.to(childNode, { alpha: 0.8, duration: 0.15 }, 0.7);
+
+	return tl;
+}
+
+/**
+ * Right rotation — mirror of left rotation.
+ */
+export function avlRightRotation(
+	pivotNode: AnimatableNode,
+	childNode: AnimatableNode,
+	pivotTarget: { x: number; y: number },
+	childTarget: { x: number; y: number },
+	rotationColor: number,
+): gsap.core.Timeline {
+	// Same animation structure — just different target positions
+	return avlLeftRotation(pivotNode, childNode, pivotTarget, childTarget, rotationColor);
+}
+
+/**
+ * Left-Right double rotation — first left-rotate the left child,
+ * then right-rotate the root.
+ */
+export function avlLeftRightRotation(
+	root: AnimatableNode,
+	leftChild: AnimatableNode,
+	leftRightChild: AnimatableNode,
+	positions: {
+		rootTarget: { x: number; y: number };
+		leftTarget: { x: number; y: number };
+		lrTarget: { x: number; y: number };
+	},
+	rotationColor: number,
+): gsap.core.Timeline {
+	const tl = gsap.timeline();
+
+	// Step 1: Highlight all three nodes
+	tl.to(root, { _fillColor: rotationColor, alpha: 1, duration: 0.12 }, 0);
+	tl.to(leftChild, { _fillColor: rotationColor, alpha: 1, duration: 0.12 }, 0);
+	tl.to(leftRightChild, { _fillColor: rotationColor, alpha: 1, duration: 0.12 }, 0);
+
+	// Step 2: Left rotate left subtree
+	if (leftChild.position) {
+		tl.to(
+			leftChild.position,
+			{ ...positions.leftTarget, duration: 0.35, ease: 'power2.inOut' },
+			0.2,
+		);
+	}
+	if (leftRightChild.position) {
+		tl.to(
+			leftRightChild.position,
+			{ ...positions.lrTarget, duration: 0.35, ease: 'power2.inOut' },
+			0.2,
+		);
+	}
+
+	// Step 3: Right rotate root
+	if (root.position) {
+		tl.to(root.position, { ...positions.rootTarget, duration: 0.35, ease: 'power2.inOut' }, 0.6);
+	}
+
+	// Step 4: Revert
+	tl.to(root, { alpha: 0.8, duration: 0.15 }, 1.05);
+	tl.to(leftChild, { alpha: 0.8, duration: 0.15 }, 1.05);
+	tl.to(leftRightChild, { alpha: 0.8, duration: 0.15 }, 1.05);
+
+	return tl;
+}
+
+/**
+ * Right-Left double rotation — mirror of Left-Right.
+ */
+export function avlRightLeftRotation(
+	root: AnimatableNode,
+	rightChild: AnimatableNode,
+	rightLeftChild: AnimatableNode,
+	positions: {
+		rootTarget: { x: number; y: number };
+		rightTarget: { x: number; y: number };
+		rlTarget: { x: number; y: number };
+	},
+	rotationColor: number,
+): gsap.core.Timeline {
+	const tl = gsap.timeline();
+
+	tl.to(root, { _fillColor: rotationColor, alpha: 1, duration: 0.12 }, 0);
+	tl.to(rightChild, { _fillColor: rotationColor, alpha: 1, duration: 0.12 }, 0);
+	tl.to(rightLeftChild, { _fillColor: rotationColor, alpha: 1, duration: 0.12 }, 0);
+
+	if (rightChild.position) {
+		tl.to(
+			rightChild.position,
+			{ ...positions.rightTarget, duration: 0.35, ease: 'power2.inOut' },
+			0.2,
+		);
+	}
+	if (rightLeftChild.position) {
+		tl.to(
+			rightLeftChild.position,
+			{ ...positions.rlTarget, duration: 0.35, ease: 'power2.inOut' },
+			0.2,
+		);
+	}
+	if (root.position) {
+		tl.to(root.position, { ...positions.rootTarget, duration: 0.35, ease: 'power2.inOut' }, 0.6);
+	}
+
+	tl.to(root, { alpha: 0.8, duration: 0.15 }, 1.05);
+	tl.to(rightChild, { alpha: 0.8, duration: 0.15 }, 1.05);
+	tl.to(rightLeftChild, { alpha: 0.8, duration: 0.15 }, 1.05);
+
+	return tl;
+}
+
+// ── Height Update ──
+
+/**
+ * Height update animation — pulses nodes from bottom to top
+ * to show height values being recalculated after a modification.
+ */
+export function avlHeightUpdate(
+	nodesBottomUp: AnimatableNode[],
+	updateColor: number,
+): gsap.core.Timeline {
+	const tl = gsap.timeline();
+
+	for (let i = 0; i < nodesBottomUp.length; i++) {
+		const node = nodesBottomUp[i];
+		const originalColor = node._fillColor ?? 0x2a2a4a;
+
+		tl.to(node, { _fillColor: updateColor, alpha: 1, duration: 0.12 }, i * 0.1);
+		tl.to(node, { _fillColor: originalColor, alpha: 0.8, duration: 0.1 }, i * 0.1 + 0.15);
+	}
+
+	return tl;
+}

--- a/src/lib/pixi/renderers/avl-tree-renderer.test.ts
+++ b/src/lib/pixi/renderers/avl-tree-renderer.test.ts
@@ -1,0 +1,267 @@
+/**
+ * Tests for AvlTreeRenderer — AVL Tree composite visualization.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { JsonValue, SceneElement } from '@/types';
+import { type AvlNodeData, AvlTreeRenderer } from './avl-tree-renderer';
+import { DEFAULT_ELEMENT_STYLE } from './shared';
+
+function createMockPixi() {
+	function MockContainer(this: Record<string, unknown>) {
+		const children: unknown[] = [];
+		this.addChild = vi.fn((...args: unknown[]) => children.push(...args));
+		this.removeChildren = vi.fn();
+		this.destroy = vi.fn();
+		this.position = { set: vi.fn(), x: 0, y: 0 };
+		this.alpha = 1;
+		this.angle = 0;
+		this.visible = true;
+		this.label = '';
+		this.cullable = false;
+		this.children = children;
+	}
+
+	function MockGraphics(this: Record<string, unknown>) {
+		this.clear = vi.fn().mockReturnThis();
+		this.rect = vi.fn().mockReturnThis();
+		this.roundRect = vi.fn().mockReturnThis();
+		this.circle = vi.fn().mockReturnThis();
+		this.fill = vi.fn().mockReturnThis();
+		this.stroke = vi.fn().mockReturnThis();
+		this.moveTo = vi.fn().mockReturnThis();
+		this.lineTo = vi.fn().mockReturnThis();
+		this.bezierCurveTo = vi.fn().mockReturnThis();
+		this.poly = vi.fn().mockReturnThis();
+		this.closePath = vi.fn().mockReturnThis();
+		this.destroy = vi.fn();
+	}
+
+	function MockText(this: Record<string, unknown>, opts: { text: string; style: unknown }) {
+		this.text = opts.text;
+		this.style = opts.style;
+		this.anchor = { set: vi.fn() };
+		this.position = { set: vi.fn() };
+		this.visible = true;
+		this.destroy = vi.fn();
+	}
+
+	function MockTextStyle(_opts: Record<string, unknown>) {
+		return { ..._opts };
+	}
+
+	return {
+		Container: vi.fn().mockImplementation(MockContainer),
+		Graphics: vi.fn().mockImplementation(MockGraphics),
+		Text: vi.fn().mockImplementation(MockText),
+		TextStyle: vi.fn().mockImplementation(MockTextStyle),
+	};
+}
+
+function makeElement(metadata: Record<string, JsonValue> = {}): SceneElement {
+	return {
+		id: 'avl-1',
+		type: 'register',
+		position: { x: 0, y: 0 },
+		size: { width: 400, height: 300 },
+		rotation: 0,
+		opacity: 1,
+		visible: true,
+		locked: false,
+		style: DEFAULT_ELEMENT_STYLE,
+		metadata,
+	};
+}
+
+const BALANCED_TREE: AvlNodeData[] = [
+	{ id: 'n1', value: 10, parentId: null, side: null, height: 2, balanceFactor: 0 },
+	{ id: 'n2', value: 5, parentId: 'n1', side: 'left', height: 1, balanceFactor: 0 },
+	{ id: 'n3', value: 15, parentId: 'n1', side: 'right', height: 1, balanceFactor: 0 },
+	{ id: 'n4', value: 3, parentId: 'n2', side: 'left', height: 0, balanceFactor: 0 },
+	{ id: 'n5', value: 7, parentId: 'n2', side: 'right', height: 0, balanceFactor: 0 },
+];
+
+const UNBALANCED_TREE: AvlNodeData[] = [
+	{ id: 'n1', value: 10, parentId: null, side: null, height: 3, balanceFactor: -2 },
+	{ id: 'n2', value: 5, parentId: 'n1', side: 'left', height: 0, balanceFactor: 0 },
+	{ id: 'n3', value: 20, parentId: 'n1', side: 'right', height: 2, balanceFactor: -1 },
+	{ id: 'n4', value: 15, parentId: 'n3', side: 'left', height: 0, balanceFactor: 0 },
+	{ id: 'n5', value: 25, parentId: 'n3', side: 'right', height: 1, balanceFactor: -1 },
+	{ id: 'n6', value: 30, parentId: 'n5', side: 'right', height: 0, balanceFactor: 0 },
+];
+
+describe('AvlTreeRenderer', () => {
+	let renderer: AvlTreeRenderer;
+	let pixi: ReturnType<typeof createMockPixi>;
+
+	beforeEach(() => {
+		pixi = createMockPixi();
+		renderer = new AvlTreeRenderer(pixi as never);
+	});
+
+	describe('render', () => {
+		it('creates a container for empty tree', () => {
+			const element = makeElement({ nodes: [] });
+			const container = renderer.render(element);
+			expect(container).toBeDefined();
+		});
+
+		it('renders balanced tree nodes', () => {
+			const element = makeElement({
+				nodes: BALANCED_TREE as unknown as JsonValue[],
+			});
+			renderer.render(element);
+
+			const containers = renderer.getNodeContainers('avl-1');
+			expect(containers).toBeDefined();
+			expect(containers?.size).toBe(5);
+		});
+
+		it('renders node values', () => {
+			const element = makeElement({
+				nodes: BALANCED_TREE as unknown as JsonValue[],
+			});
+			renderer.render(element);
+
+			const textCalls = pixi.Text.mock.calls;
+			const values = textCalls
+				.map((c: unknown[]) => (c[0] as { text: string }).text)
+				.filter((t: string) => !Number.isNaN(Number(t)));
+			expect(values).toContain('10');
+			expect(values).toContain('5');
+			expect(values).toContain('15');
+		});
+
+		it('renders balance factor badges by default', () => {
+			const element = makeElement({
+				nodes: BALANCED_TREE as unknown as JsonValue[],
+			});
+			renderer.render(element);
+
+			const textCalls = pixi.Text.mock.calls;
+			// Balance factor "0" should appear for balanced nodes
+			const bfTexts = textCalls.filter((c: unknown[]) => (c[0] as { text: string }).text === '0');
+			expect(bfTexts.length).toBeGreaterThan(0);
+		});
+
+		it('renders unbalanced factor badges with correct values', () => {
+			const element = makeElement({
+				nodes: UNBALANCED_TREE as unknown as JsonValue[],
+			});
+			renderer.render(element);
+
+			const textCalls = pixi.Text.mock.calls;
+			const bfValues = textCalls
+				.map((c: unknown[]) => (c[0] as { text: string }).text)
+				.filter((t: string) => t === '-2' || t === '-1');
+			expect(bfValues).toContain('-2');
+			expect(bfValues).toContain('-1');
+		});
+
+		it('hides balance factor when showBalanceFactor is false', () => {
+			const element = makeElement({
+				nodes: [
+					{ id: 'n1', value: 10, parentId: null, side: null, height: 0, balanceFactor: 0 },
+				] as unknown as JsonValue[],
+				showBalanceFactor: false,
+			});
+			renderer.render(element);
+
+			// Only value text + no badge = just "10"
+			const graphicsCalls = pixi.Graphics.mock.results;
+			// Node circle only — no badge circle
+			const circleCount = graphicsCalls.reduce(
+				(count: number, r: { type: string; value?: unknown }) => {
+					const v = r.value as Record<string, { mock: { calls: unknown[][] } }> | undefined;
+					return count + (v?.circle?.mock?.calls?.length ?? 0);
+				},
+				0,
+			);
+			expect(circleCount).toBe(1); // Just the node, no badge
+		});
+
+		it('renders height labels when showHeight is true', () => {
+			const element = makeElement({
+				nodes: BALANCED_TREE as unknown as JsonValue[],
+				showHeight: true,
+			});
+			renderer.render(element);
+
+			const textCalls = pixi.Text.mock.calls;
+			const heightTexts = textCalls.filter((c: unknown[]) =>
+				(c[0] as { text: string }).text.startsWith('h='),
+			);
+			expect(heightTexts.length).toBe(5);
+		});
+
+		it('does not render height labels by default', () => {
+			const element = makeElement({
+				nodes: BALANCED_TREE as unknown as JsonValue[],
+			});
+			renderer.render(element);
+
+			const textCalls = pixi.Text.mock.calls;
+			const heightTexts = textCalls.filter((c: unknown[]) =>
+				(c[0] as { text: string }).text.startsWith('h='),
+			);
+			expect(heightTexts.length).toBe(0);
+		});
+
+		it('renders rotation indicator', () => {
+			const element = makeElement({
+				nodes: BALANCED_TREE as unknown as JsonValue[],
+				rotationIndicator: 'Left Rotation',
+			});
+			renderer.render(element);
+
+			const textCalls = pixi.Text.mock.calls;
+			const rotText = textCalls.find(
+				(c: unknown[]) => (c[0] as { text: string }).text === 'Left Rotation',
+			);
+			expect(rotText).toBeDefined();
+		});
+
+		it('draws edges between parent and child', () => {
+			const element = makeElement({
+				nodes: [
+					{ id: 'n1', value: 10, parentId: null, side: null, height: 1, balanceFactor: 0 },
+					{ id: 'n2', value: 5, parentId: 'n1', side: 'left', height: 0, balanceFactor: 0 },
+				] as unknown as JsonValue[],
+			});
+			renderer.render(element);
+
+			// Should call moveTo + lineTo for the edge
+			const graphicsResults = pixi.Graphics.mock.results;
+			const hasLine = graphicsResults.some((r: { type: string; value?: unknown }) => {
+				const v = r.value as Record<string, { mock: { calls: unknown[][] } }> | undefined;
+				return (
+					(v?.moveTo?.mock?.calls?.length ?? 0) > 0 && (v?.lineTo?.mock?.calls?.length ?? 0) > 0
+				);
+			});
+			expect(hasLine).toBe(true);
+		});
+	});
+
+	describe('getNodeContainers', () => {
+		it('returns undefined for unknown element', () => {
+			expect(renderer.getNodeContainers('nonexistent')).toBeUndefined();
+		});
+	});
+
+	describe('getNodePositions', () => {
+		it('returns positions after render', () => {
+			const element = makeElement({
+				nodes: BALANCED_TREE as unknown as JsonValue[],
+			});
+			renderer.render(element);
+
+			const positions = renderer.getNodePositions('avl-1');
+			expect(positions).toBeDefined();
+			expect(positions?.size).toBe(5);
+		});
+
+		it('returns undefined for unknown element', () => {
+			expect(renderer.getNodePositions('nonexistent')).toBeUndefined();
+		});
+	});
+});

--- a/src/lib/pixi/renderers/avl-tree-renderer.ts
+++ b/src/lib/pixi/renderers/avl-tree-renderer.ts
@@ -1,0 +1,347 @@
+/**
+ * Renderer for AVL Tree composite elements.
+ *
+ * Extends the binary tree visualization with:
+ * - Balance factor display per node (color-coded: green=balanced, red=unbalanced)
+ * - Height tracking per node
+ * - Rotation indicator arrows
+ *
+ * Uses the same hierarchical layout as TreeRenderer but adds AVL-specific
+ * metadata overlays. Node containers are stored for GSAP rotation animations.
+ *
+ * Spec reference: Section 6.3.1 (AVL Tree)
+ */
+
+import type { SceneElement } from '@/types';
+import { hexToPixiColor } from './shared';
+
+// ── Pixi.js DI interfaces ──
+
+interface PixiContainer {
+	addChild(...children: unknown[]): void;
+	removeChildren(): void;
+	destroy(options?: { children: boolean }): void;
+	position: { set(x: number, y: number): void; x: number; y: number };
+	alpha: number;
+	angle: number;
+	visible: boolean;
+	label: string;
+	cullable: boolean;
+	children: unknown[];
+}
+
+interface PixiGraphics {
+	clear(): PixiGraphics;
+	rect(x: number, y: number, w: number, h: number): PixiGraphics;
+	roundRect(x: number, y: number, w: number, h: number, r: number): PixiGraphics;
+	circle(x: number, y: number, r: number): PixiGraphics;
+	fill(opts: { color: number; alpha?: number } | number): PixiGraphics;
+	stroke(opts: { width: number; color: number; alpha?: number }): PixiGraphics;
+	moveTo(x: number, y: number): PixiGraphics;
+	lineTo(x: number, y: number): PixiGraphics;
+	bezierCurveTo(
+		cp1x: number,
+		cp1y: number,
+		cp2x: number,
+		cp2y: number,
+		x: number,
+		y: number,
+	): PixiGraphics;
+	poly(points: number[]): PixiGraphics;
+	closePath(): PixiGraphics;
+	destroy(): void;
+}
+
+interface PixiText {
+	text: string;
+	style: Record<string, unknown>;
+	anchor: { set(x: number, y: number): void };
+	position: { set(x: number, y: number): void };
+	visible: boolean;
+	destroy(): void;
+}
+
+interface PixiModule {
+	Container: new () => PixiContainer;
+	Graphics: new () => PixiGraphics;
+	Text: new (opts: { text: string; style: unknown }) => PixiText;
+	TextStyle: new (opts: Record<string, unknown>) => Record<string, unknown>;
+}
+
+// ── AVL Types ──
+
+export interface AvlNodeData {
+	id: string;
+	value: number;
+	parentId: string | null;
+	side: 'left' | 'right' | null;
+	height: number;
+	balanceFactor: number;
+}
+
+interface NodePosition {
+	x: number;
+	y: number;
+}
+
+// ── Balance Factor Colors ──
+
+const BF_COLORS = {
+	balanced: '#4ade80',
+	warning: '#fbbf24',
+	unbalanced: '#ef4444',
+};
+
+function getBalanceColor(bf: number): string {
+	const absBf = Math.abs(bf);
+	if (absBf <= 1) return BF_COLORS.balanced;
+	if (absBf === 2) return BF_COLORS.warning;
+	return BF_COLORS.unbalanced;
+}
+
+/**
+ * Renderer for AVL Tree composite elements.
+ */
+export class AvlTreeRenderer {
+	private pixi: PixiModule;
+	private nodeContainers: Record<string, Map<string, PixiContainer>> = {};
+	private nodePositions: Record<string, Map<string, NodePosition>> = {};
+
+	constructor(pixi: PixiModule) {
+		this.pixi = pixi;
+	}
+
+	/**
+	 * Render an AVL tree element.
+	 */
+	render(element: SceneElement): PixiContainer {
+		const container = new this.pixi.Container();
+		const { style, metadata } = element;
+
+		const rawNodes = (metadata.nodes as unknown as AvlNodeData[]) ?? [];
+		const nodeSize = (metadata.nodeSize as number) ?? 20;
+		const levelGap = (metadata.levelGap as number) ?? 60;
+		const nodeGap = (metadata.nodeGap as number) ?? 30;
+		const highlightedNodes = (metadata.highlightedNodes as string[]) ?? [];
+		const highlightColor = (metadata.highlightColor as string) ?? '#3b82f6';
+		const showBalanceFactor = (metadata.showBalanceFactor as boolean) ?? true;
+		const showHeight = (metadata.showHeight as boolean) ?? false;
+		const rotationIndicator = (metadata.rotationIndicator as string) ?? '';
+
+		if (rawNodes.length === 0) {
+			this.nodeContainers[element.id] = new Map();
+			this.nodePositions[element.id] = new Map();
+			return container;
+		}
+
+		const fillColor = hexToPixiColor(style.fill);
+		const strokeColor = hexToPixiColor(style.stroke);
+		const highlightPixi = hexToPixiColor(highlightColor);
+
+		// Compute layout
+		const positions = this.computeLayout(rawNodes, nodeSize, levelGap, nodeGap);
+		const nodeMap = new Map<string, PixiContainer>();
+		const posMap = new Map<string, NodePosition>();
+
+		// Pass 1: Draw edges
+		for (const node of rawNodes) {
+			if (!node.parentId) continue;
+			const parentPos = positions.get(node.parentId);
+			const childPos = positions.get(node.id);
+			if (!parentPos || !childPos) continue;
+
+			const edgeG = new this.pixi.Graphics();
+			edgeG.moveTo(parentPos.x, parentPos.y + nodeSize);
+			edgeG.lineTo(childPos.x, childPos.y - nodeSize);
+			edgeG.stroke({ width: style.strokeWidth, color: strokeColor });
+			container.addChild(edgeG);
+		}
+
+		// Pass 2: Draw nodes
+		for (const node of rawNodes) {
+			const pos = positions.get(node.id);
+			if (!pos) continue;
+
+			posMap.set(node.id, pos);
+			const isHighlighted = highlightedNodes.includes(node.id);
+
+			// Node circle
+			const g = new this.pixi.Graphics();
+			g.circle(pos.x, pos.y, nodeSize);
+			g.fill({ color: isHighlighted ? highlightPixi : fillColor });
+			g.stroke({ width: style.strokeWidth, color: strokeColor });
+			container.addChild(g);
+
+			// Value text
+			const textStyle = new this.pixi.TextStyle({
+				fontSize: style.fontSize,
+				fontFamily: style.fontFamily,
+				fontWeight: String(style.fontWeight),
+				fill: hexToPixiColor(style.textColor),
+			});
+			const valueText = new this.pixi.Text({
+				text: String(node.value),
+				style: textStyle,
+			});
+			valueText.anchor.set(0.5, 0.5);
+			valueText.position.set(pos.x, pos.y);
+			container.addChild(valueText);
+
+			// Balance factor badge
+			if (showBalanceFactor) {
+				const bfColor = getBalanceColor(node.balanceFactor);
+				const badgeG = new this.pixi.Graphics();
+				badgeG.circle(pos.x + nodeSize + 4, pos.y - nodeSize + 4, 8);
+				badgeG.fill({ color: hexToPixiColor(bfColor), alpha: 0.8 });
+				container.addChild(badgeG);
+
+				const bfStyle = new this.pixi.TextStyle({
+					fontSize: 8,
+					fontFamily: style.fontFamily,
+					fontWeight: '700',
+					fill: hexToPixiColor('#ffffff'),
+				});
+				const bfText = new this.pixi.Text({
+					text: String(node.balanceFactor),
+					style: bfStyle,
+				});
+				bfText.anchor.set(0.5, 0.5);
+				bfText.position.set(pos.x + nodeSize + 4, pos.y - nodeSize + 4);
+				container.addChild(bfText);
+			}
+
+			// Height label
+			if (showHeight) {
+				const heightStyle = new this.pixi.TextStyle({
+					fontSize: 8,
+					fontFamily: style.fontFamily,
+					fontWeight: '400',
+					fill: hexToPixiColor('#9ca3af'),
+				});
+				const heightText = new this.pixi.Text({
+					text: `h=${node.height}`,
+					style: heightStyle,
+				});
+				heightText.anchor.set(0.5, 0);
+				heightText.position.set(pos.x, pos.y + nodeSize + 4);
+				container.addChild(heightText);
+			}
+
+			nodeMap.set(node.id, container);
+		}
+
+		// Rotation indicator text
+		if (rotationIndicator) {
+			const rotStyle = new this.pixi.TextStyle({
+				fontSize: 12,
+				fontFamily: style.fontFamily,
+				fontWeight: '700',
+				fill: hexToPixiColor('#f97316'),
+			});
+			const rotText = new this.pixi.Text({
+				text: rotationIndicator,
+				style: rotStyle,
+			});
+			rotText.anchor.set(0.5, 0);
+			rotText.position.set(element.size.width / 2, -20);
+			container.addChild(rotText);
+		}
+
+		this.nodeContainers[element.id] = nodeMap;
+		this.nodePositions[element.id] = posMap;
+		return container;
+	}
+
+	/**
+	 * Get node containers for animation targeting.
+	 */
+	getNodeContainers(elementId: string): Map<string, PixiContainer> | undefined {
+		return this.nodeContainers[elementId];
+	}
+
+	/**
+	 * Get computed node positions for animation.
+	 */
+	getNodePositions(elementId: string): Map<string, NodePosition> | undefined {
+		return this.nodePositions[elementId];
+	}
+
+	/**
+	 * Compute hierarchical tree layout from flat node list.
+	 * Same algorithm as TreeRenderer — centered binary tree layout.
+	 */
+	private computeLayout(
+		nodes: AvlNodeData[],
+		nodeSize: number,
+		levelGap: number,
+		nodeGap: number,
+	): Map<string, NodePosition> {
+		const positions = new Map<string, NodePosition>();
+
+		// Build adjacency: parentId → children
+		const childrenMap = new Map<string, { left?: string; right?: string }>();
+		let rootId: string | null = null;
+
+		for (const node of nodes) {
+			if (!node.parentId) {
+				rootId = node.id;
+			} else {
+				const siblings = childrenMap.get(node.parentId) ?? {};
+				if (node.side === 'left') siblings.left = node.id;
+				else siblings.right = node.id;
+				childrenMap.set(node.parentId, siblings);
+			}
+		}
+
+		if (!rootId) return positions;
+
+		// BFS to assign levels
+		const levels = new Map<string, number>();
+		const queue: string[] = [rootId];
+		levels.set(rootId, 0);
+
+		while (queue.length > 0) {
+			const current = queue.shift()!;
+			const children = childrenMap.get(current);
+			const currentLevel = levels.get(current)!;
+
+			if (children?.left) {
+				levels.set(children.left, currentLevel + 1);
+				queue.push(children.left);
+			}
+			if (children?.right) {
+				levels.set(children.right, currentLevel + 1);
+				queue.push(children.right);
+			}
+		}
+
+		// In-order traversal for x positions
+		let xIndex = 0;
+		const xPositions = new Map<string, number>();
+
+		const inOrder = (nodeId: string): void => {
+			const children = childrenMap.get(nodeId);
+			if (children?.left) inOrder(children.left);
+			xPositions.set(nodeId, xIndex);
+			xIndex++;
+			if (children?.right) inOrder(children.right);
+		};
+
+		inOrder(rootId);
+
+		// Convert to pixel positions
+		const spacing = nodeSize * 2 + nodeGap;
+		for (const node of nodes) {
+			const xIdx = xPositions.get(node.id);
+			const level = levels.get(node.id);
+			if (xIdx === undefined || level === undefined) continue;
+
+			positions.set(node.id, {
+				x: xIdx * spacing + nodeSize,
+				y: level * levelGap + nodeSize,
+			});
+		}
+
+		return positions;
+	}
+}


### PR DESCRIPTION
## Summary
- Add `AvlTreeRenderer` extending binary tree visualization with balance factor badges (green=balanced, yellow=warning, red=unbalanced), optional height labels, and rotation indicator text
- Add 6 GSAP animation presets: `avlInsertRebalance`, `avlLeftRotation`, `avlRightRotation`, `avlLeftRightRotation`, `avlRightLeftRotation`, `avlHeightUpdate`
- 29 new tests (13 renderer + 16 presets), total suite now at 1158 tests across 81 files

## Test plan
- [x] Renderer creates container for empty and populated trees
- [x] Node values and balance factors render correctly
- [x] Balance factor badges hidden when `showBalanceFactor: false`
- [x] Height labels shown only when `showHeight: true`
- [x] Rotation indicator text displays when specified
- [x] Edges drawn between parent-child nodes
- [x] Unbalanced tree renders correct BF values (-2, -1)
- [x] All 6 GSAP presets return timelines with correct duration
- [x] Double rotations are longer than single rotations
- [x] Insert path scales duration with path length
- [x] Height update scales with node count
- [x] Biome clean, tsc clean, all 1158 tests pass

Closes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)