### PR TITLE
feat: implement Heap composite with heapify animations (#47)

### DIFF
--- a/src/lib/gsap/presets/heap-presets.test.ts
+++ b/src/lib/gsap/presets/heap-presets.test.ts
@@ -1,0 +1,156 @@
+/**
+ * Tests for Heap GSAP animation presets.
+ */
+
+import gsap from 'gsap';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+	heapArrayTreeSync,
+	heapBuildFloyd,
+	heapExtract,
+	heapSiftDown,
+	heapSiftUp,
+} from './heap-presets';
+
+interface MockNode {
+	alpha: number;
+	_fillColor: number;
+	position: { x: number; y: number };
+}
+
+function makeNode(): MockNode {
+	return { alpha: 0.8, _fillColor: 0x2a2a4a, position: { x: 100, y: 100 } };
+}
+
+describe('Heap Animation Presets', () => {
+	beforeEach(() => {
+		gsap.ticker.lagSmoothing(0);
+	});
+
+	describe('heapSiftUp', () => {
+		it('returns a GSAP timeline', () => {
+			const tl = heapSiftUp([makeNode(), makeNode(), makeNode()], 0x4ade80, 0xf97316);
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+		});
+
+		it('has positive duration', () => {
+			const tl = heapSiftUp([makeNode(), makeNode()], 0x4ade80, 0xf97316);
+			expect(tl.duration()).toBeGreaterThan(0);
+		});
+
+		it('handles empty path', () => {
+			const tl = heapSiftUp([], 0x4ade80, 0xf97316);
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+			expect(tl.duration()).toBe(0);
+		});
+
+		it('duration scales with path length', () => {
+			const short = heapSiftUp([makeNode(), makeNode()], 0x4ade80, 0xf97316);
+			const long = heapSiftUp([makeNode(), makeNode(), makeNode(), makeNode()], 0x4ade80, 0xf97316);
+			expect(long.duration()).toBeGreaterThan(short.duration());
+		});
+	});
+
+	describe('heapSiftDown', () => {
+		it('returns a GSAP timeline', () => {
+			const tl = heapSiftDown([makeNode(), makeNode()], 0x3b82f6, 0xf97316);
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+		});
+
+		it('has positive duration', () => {
+			const tl = heapSiftDown([makeNode(), makeNode(), makeNode()], 0x3b82f6, 0xf97316);
+			expect(tl.duration()).toBeGreaterThan(0);
+		});
+
+		it('handles empty path', () => {
+			const tl = heapSiftDown([], 0x3b82f6, 0xf97316);
+			expect(tl.duration()).toBe(0);
+		});
+	});
+
+	describe('heapExtract', () => {
+		it('returns a GSAP timeline', () => {
+			const tl = heapExtract(
+				makeNode(),
+				makeNode(),
+				[makeNode(), makeNode()],
+				0xef4444,
+				0xfbbf24,
+				0x3b82f6,
+			);
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+		});
+
+		it('has positive duration', () => {
+			const tl = heapExtract(makeNode(), makeNode(), [makeNode()], 0xef4444, 0xfbbf24, 0x3b82f6);
+			expect(tl.duration()).toBeGreaterThan(0);
+		});
+
+		it('has longer duration than sift down alone', () => {
+			const sift = heapSiftDown([makeNode(), makeNode()], 0x3b82f6, 0xf97316);
+			const extract = heapExtract(
+				makeNode(),
+				makeNode(),
+				[makeNode(), makeNode()],
+				0xef4444,
+				0xfbbf24,
+				0x3b82f6,
+			);
+			expect(extract.duration()).toBeGreaterThan(sift.duration());
+		});
+	});
+
+	describe('heapBuildFloyd', () => {
+		it('returns a GSAP timeline', () => {
+			const tl = heapBuildFloyd([makeNode(), makeNode(), makeNode()], 0xf97316, 0x4ade80);
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+		});
+
+		it('has positive duration', () => {
+			const tl = heapBuildFloyd([makeNode(), makeNode()], 0xf97316, 0x4ade80);
+			expect(tl.duration()).toBeGreaterThan(0);
+		});
+
+		it('handles empty nodes', () => {
+			const tl = heapBuildFloyd([], 0xf97316, 0x4ade80);
+			expect(tl.duration()).toBe(0);
+		});
+
+		it('duration scales with node count', () => {
+			const short = heapBuildFloyd([makeNode()], 0xf97316, 0x4ade80);
+			const long = heapBuildFloyd(
+				[makeNode(), makeNode(), makeNode(), makeNode()],
+				0xf97316,
+				0x4ade80,
+			);
+			expect(long.duration()).toBeGreaterThan(short.duration());
+		});
+	});
+
+	describe('heapArrayTreeSync', () => {
+		it('returns a GSAP timeline', () => {
+			const tl = heapArrayTreeSync([makeNode(), makeNode()], [makeNode(), makeNode()], 0x3b82f6);
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+		});
+
+		it('has positive duration', () => {
+			const tl = heapArrayTreeSync(
+				[makeNode(), makeNode(), makeNode()],
+				[makeNode(), makeNode(), makeNode()],
+				0x3b82f6,
+			);
+			expect(tl.duration()).toBeGreaterThan(0);
+		});
+
+		it('handles empty arrays', () => {
+			const tl = heapArrayTreeSync([], [], 0x3b82f6);
+			expect(tl.duration()).toBe(0);
+		});
+
+		it('handles mismatched lengths', () => {
+			const tl = heapArrayTreeSync([makeNode(), makeNode(), makeNode()], [makeNode()], 0x3b82f6);
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+			expect(tl.duration()).toBeGreaterThan(0);
+		});
+	});
+});

--- a/src/lib/gsap/presets/heap-presets.ts
+++ b/src/lib/gsap/presets/heap-presets.ts
@@ -1,0 +1,196 @@
+/**
+ * GSAP animation presets for Heap composite.
+ *
+ * Provides heap-specific animations:
+ * - Heapify up (sift up / bubble up after insert)
+ * - Heapify down (sift down / trickle down after extract)
+ * - Extract-min/max (remove root, replace, heapify)
+ * - Build heap (Floyd's bottom-up algorithm)
+ * - Array-tree sync highlight
+ *
+ * Spec reference: Section 6.3.1 (Heap), Section 9.3 (Animation Presets)
+ */
+
+import gsap from 'gsap';
+
+interface AnimatableNode {
+	alpha: number;
+	_fillColor?: number;
+	position?: { x: number; y: number };
+}
+
+// ── Heapify Up (Sift Up) ──
+
+/**
+ * Heapify up — animates bubble-up after insert.
+ * Highlights path from leaf to root, swapping along the way.
+ */
+export function heapSiftUp(
+	pathNodes: AnimatableNode[],
+	insertColor: number,
+	swapColor: number,
+): gsap.core.Timeline {
+	const tl = gsap.timeline();
+
+	if (pathNodes.length === 0) return tl;
+
+	// Step 1: Highlight inserted node
+	const inserted = pathNodes[pathNodes.length - 1];
+	tl.to(inserted, { _fillColor: insertColor, alpha: 1, duration: 0.15 }, 0);
+
+	// Step 2: Compare and swap up the path
+	for (let i = pathNodes.length - 1; i > 0; i--) {
+		const child = pathNodes[i];
+		const parent = pathNodes[i - 1];
+		const reverseIdx = pathNodes.length - 1 - i;
+		const offset = 0.2 + reverseIdx * 0.25;
+
+		// Highlight parent for comparison
+		tl.to(parent, { _fillColor: swapColor, alpha: 1, duration: 0.1 }, offset);
+
+		// Swap flash
+		tl.to(child, { _fillColor: swapColor, duration: 0.1 }, offset + 0.12);
+		tl.to(child, { alpha: 0.8, duration: 0.08 }, offset + 0.22);
+		tl.to(parent, { alpha: 0.8, duration: 0.08 }, offset + 0.22);
+	}
+
+	return tl;
+}
+
+// ── Heapify Down (Sift Down) ──
+
+/**
+ * Heapify down — animates trickle-down from root.
+ * Highlights path from root downward, comparing with children.
+ */
+export function heapSiftDown(
+	pathNodes: AnimatableNode[],
+	compareColor: number,
+	swapColor: number,
+): gsap.core.Timeline {
+	const tl = gsap.timeline();
+
+	if (pathNodes.length === 0) return tl;
+
+	for (let i = 0; i < pathNodes.length; i++) {
+		const node = pathNodes[i];
+		const offset = i * 0.25;
+
+		// Highlight current node
+		tl.to(node, { _fillColor: compareColor, alpha: 1, duration: 0.1 }, offset);
+
+		// Swap indication
+		if (i < pathNodes.length - 1) {
+			tl.to(node, { _fillColor: swapColor, duration: 0.1 }, offset + 0.12);
+		}
+
+		// Settle
+		tl.to(node, { alpha: 0.8, duration: 0.08 }, offset + 0.22);
+	}
+
+	return tl;
+}
+
+// ── Extract Min/Max ──
+
+/**
+ * Extract-min/max — removes root, replaces with last element,
+ * then heapifies down. Three-phase animation.
+ */
+export function heapExtract(
+	rootNode: AnimatableNode,
+	lastNode: AnimatableNode,
+	siftPath: AnimatableNode[],
+	extractColor: number,
+	replaceColor: number,
+	siftColor: number,
+): gsap.core.Timeline {
+	const tl = gsap.timeline();
+
+	// Phase 1: Highlight root being extracted
+	tl.to(rootNode, { _fillColor: extractColor, alpha: 1, duration: 0.2 }, 0);
+	tl.to(rootNode, { alpha: 0, duration: 0.2, ease: 'power2.in' }, 0.25);
+
+	// Phase 2: Last node moves to root position
+	tl.to(lastNode, { _fillColor: replaceColor, alpha: 1, duration: 0.15 }, 0.5);
+	if (lastNode.position && rootNode.position) {
+		tl.to(
+			lastNode.position,
+			{
+				x: rootNode.position.x,
+				y: rootNode.position.y,
+				duration: 0.3,
+				ease: 'power2.inOut',
+			},
+			0.5,
+		);
+	}
+
+	// Phase 3: Sift down
+	for (let i = 0; i < siftPath.length; i++) {
+		const node = siftPath[i];
+		const offset = 0.9 + i * 0.2;
+		tl.to(node, { _fillColor: siftColor, alpha: 1, duration: 0.1 }, offset);
+		tl.to(node, { alpha: 0.8, duration: 0.08 }, offset + 0.12);
+	}
+
+	return tl;
+}
+
+// ── Build Heap (Floyd's Algorithm) ──
+
+/**
+ * Build heap — Floyd's bottom-up algorithm.
+ * Processes nodes from the last internal node to root.
+ */
+export function heapBuildFloyd(
+	internalNodes: AnimatableNode[],
+	buildColor: number,
+	settleColor: number,
+): gsap.core.Timeline {
+	const tl = gsap.timeline();
+
+	for (let i = 0; i < internalNodes.length; i++) {
+		const node = internalNodes[i];
+		const offset = i * 0.2;
+
+		// Highlight node being heapified
+		tl.to(node, { _fillColor: buildColor, alpha: 1, duration: 0.12 }, offset);
+		// Settle after heapify
+		tl.to(node, { _fillColor: settleColor, alpha: 0.8, duration: 0.1 }, offset + 0.15);
+	}
+
+	return tl;
+}
+
+// ── Array-Tree Sync ──
+
+/**
+ * Array-tree sync — highlights corresponding positions in
+ * both the tree and array views simultaneously.
+ */
+export function heapArrayTreeSync(
+	treeNodes: AnimatableNode[],
+	arrayCells: AnimatableNode[],
+	syncColor: number,
+): gsap.core.Timeline {
+	const tl = gsap.timeline();
+
+	const count = Math.min(treeNodes.length, arrayCells.length);
+
+	for (let i = 0; i < count; i++) {
+		const tree = treeNodes[i];
+		const cell = arrayCells[i];
+		const offset = i * 0.15;
+
+		// Highlight both simultaneously
+		tl.to(tree, { _fillColor: syncColor, alpha: 1, duration: 0.12 }, offset);
+		tl.to(cell, { _fillColor: syncColor, alpha: 1, duration: 0.12 }, offset);
+
+		// Revert
+		tl.to(tree, { alpha: 0.8, duration: 0.08 }, offset + 0.15);
+		tl.to(cell, { alpha: 0.8, duration: 0.08 }, offset + 0.15);
+	}
+
+	return tl;
+}

--- a/src/lib/pixi/renderers/heap-renderer.test.ts
+++ b/src/lib/pixi/renderers/heap-renderer.test.ts
@@ -1,0 +1,303 @@
+/**
+ * Tests for HeapRenderer — Heap composite with tree + array views.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { JsonValue, SceneElement } from '@/types';
+import { type HeapNodeData, HeapRenderer } from './heap-renderer';
+import { DEFAULT_ELEMENT_STYLE } from './shared';
+
+function createMockPixi() {
+	function MockContainer(this: Record<string, unknown>) {
+		const children: unknown[] = [];
+		this.addChild = vi.fn((...args: unknown[]) => children.push(...args));
+		this.removeChildren = vi.fn();
+		this.destroy = vi.fn();
+		this.position = { set: vi.fn(), x: 0, y: 0 };
+		this.alpha = 1;
+		this.angle = 0;
+		this.visible = true;
+		this.label = '';
+		this.cullable = false;
+		this.children = children;
+	}
+
+	function MockGraphics(this: Record<string, unknown>) {
+		this.clear = vi.fn().mockReturnThis();
+		this.rect = vi.fn().mockReturnThis();
+		this.roundRect = vi.fn().mockReturnThis();
+		this.circle = vi.fn().mockReturnThis();
+		this.fill = vi.fn().mockReturnThis();
+		this.stroke = vi.fn().mockReturnThis();
+		this.moveTo = vi.fn().mockReturnThis();
+		this.lineTo = vi.fn().mockReturnThis();
+		this.bezierCurveTo = vi.fn().mockReturnThis();
+		this.poly = vi.fn().mockReturnThis();
+		this.closePath = vi.fn().mockReturnThis();
+		this.destroy = vi.fn();
+	}
+
+	function MockText(this: Record<string, unknown>, opts: { text: string; style: unknown }) {
+		this.text = opts.text;
+		this.style = opts.style;
+		this.anchor = { set: vi.fn() };
+		this.position = { set: vi.fn() };
+		this.visible = true;
+		this.destroy = vi.fn();
+	}
+
+	function MockTextStyle(_opts: Record<string, unknown>) {
+		return { ..._opts };
+	}
+
+	return {
+		Container: vi.fn().mockImplementation(MockContainer),
+		Graphics: vi.fn().mockImplementation(MockGraphics),
+		Text: vi.fn().mockImplementation(MockText),
+		TextStyle: vi.fn().mockImplementation(MockTextStyle),
+	};
+}
+
+function makeElement(metadata: Record<string, JsonValue> = {}): SceneElement {
+	return {
+		id: 'heap-1',
+		type: 'register',
+		position: { x: 0, y: 0 },
+		size: { width: 500, height: 400 },
+		rotation: 0,
+		opacity: 1,
+		visible: true,
+		locked: false,
+		style: DEFAULT_ELEMENT_STYLE,
+		metadata,
+	};
+}
+
+const MAX_HEAP: HeapNodeData[] = [
+	{ index: 0, value: 90 },
+	{ index: 1, value: 70 },
+	{ index: 2, value: 80 },
+	{ index: 3, value: 30 },
+	{ index: 4, value: 50 },
+	{ index: 5, value: 60 },
+	{ index: 6, value: 40 },
+];
+
+const MIN_HEAP: HeapNodeData[] = [
+	{ index: 0, value: 10 },
+	{ index: 1, value: 20 },
+	{ index: 2, value: 15 },
+];
+
+describe('HeapRenderer', () => {
+	let renderer: HeapRenderer;
+	let pixi: ReturnType<typeof createMockPixi>;
+
+	beforeEach(() => {
+		pixi = createMockPixi();
+		renderer = new HeapRenderer(pixi as never);
+	});
+
+	describe('render', () => {
+		it('creates a container for empty heap', () => {
+			const element = makeElement({ nodes: [] });
+			const container = renderer.render(element);
+			expect(container).toBeDefined();
+		});
+
+		it('renders max-heap with correct type label', () => {
+			const element = makeElement({
+				nodes: MAX_HEAP as unknown as JsonValue[],
+				heapType: 'max',
+			});
+			renderer.render(element);
+
+			const textCalls = pixi.Text.mock.calls;
+			const typeLabel = textCalls.find(
+				(c: unknown[]) => (c[0] as { text: string }).text === 'Max-Heap',
+			);
+			expect(typeLabel).toBeDefined();
+		});
+
+		it('renders min-heap with correct type label', () => {
+			const element = makeElement({
+				nodes: MIN_HEAP as unknown as JsonValue[],
+				heapType: 'min',
+			});
+			renderer.render(element);
+
+			const textCalls = pixi.Text.mock.calls;
+			const typeLabel = textCalls.find(
+				(c: unknown[]) => (c[0] as { text: string }).text === 'Min-Heap',
+			);
+			expect(typeLabel).toBeDefined();
+		});
+
+		it('renders node values in tree view', () => {
+			const element = makeElement({
+				nodes: MAX_HEAP as unknown as JsonValue[],
+			});
+			renderer.render(element);
+
+			const textCalls = pixi.Text.mock.calls;
+			const values = textCalls
+				.map((c: unknown[]) => (c[0] as { text: string }).text)
+				.filter((t: string) => t === '90' || t === '70' || t === '80');
+			expect(values).toContain('90');
+			expect(values).toContain('70');
+			expect(values).toContain('80');
+		});
+
+		it('draws edges between parent and child nodes', () => {
+			const element = makeElement({
+				nodes: MIN_HEAP as unknown as JsonValue[],
+			});
+			renderer.render(element);
+
+			const graphicsResults = pixi.Graphics.mock.results;
+			const hasLine = graphicsResults.some((r: { type: string; value?: unknown }) => {
+				const v = r.value as Record<string, { mock: { calls: unknown[][] } }> | undefined;
+				return (
+					(v?.moveTo?.mock?.calls?.length ?? 0) > 0 && (v?.lineTo?.mock?.calls?.length ?? 0) > 0
+				);
+			});
+			expect(hasLine).toBe(true);
+		});
+
+		it('renders array overlay by default', () => {
+			const element = makeElement({
+				nodes: MIN_HEAP as unknown as JsonValue[],
+			});
+			renderer.render(element);
+
+			const textCalls = pixi.Text.mock.calls;
+			const arrayLabel = textCalls.find(
+				(c: unknown[]) => (c[0] as { text: string }).text === 'Array:',
+			);
+			expect(arrayLabel).toBeDefined();
+		});
+
+		it('hides array when showArray is false', () => {
+			const element = makeElement({
+				nodes: MIN_HEAP as unknown as JsonValue[],
+				showArray: false,
+			});
+			renderer.render(element);
+
+			const textCalls = pixi.Text.mock.calls;
+			const arrayLabel = textCalls.find(
+				(c: unknown[]) => (c[0] as { text: string }).text === 'Array:',
+			);
+			expect(arrayLabel).toBeUndefined();
+		});
+
+		it('renders index labels when showIndices is true', () => {
+			const element = makeElement({
+				nodes: MIN_HEAP as unknown as JsonValue[],
+				showIndices: true,
+			});
+			renderer.render(element);
+
+			const textCalls = pixi.Text.mock.calls;
+			// Index "0", "1", "2" should appear (tree indices + array indices)
+			const indexTexts = textCalls.filter(
+				(c: unknown[]) => (c[0] as { text: string }).text === '0',
+			);
+			expect(indexTexts.length).toBeGreaterThan(0);
+		});
+
+		it('renders array cells as rectangles', () => {
+			const element = makeElement({
+				nodes: MIN_HEAP as unknown as JsonValue[],
+			});
+			renderer.render(element);
+
+			const graphicsResults = pixi.Graphics.mock.results;
+			const hasRect = graphicsResults.some((r: { type: string; value?: unknown }) => {
+				const v = r.value as Record<string, { mock: { calls: unknown[][] } }> | undefined;
+				return (v?.rect?.mock?.calls?.length ?? 0) > 0;
+			});
+			expect(hasRect).toBe(true);
+		});
+	});
+
+	describe('getNodeContainers', () => {
+		it('returns containers after render', () => {
+			const element = makeElement({
+				nodes: MAX_HEAP as unknown as JsonValue[],
+			});
+			renderer.render(element);
+
+			const containers = renderer.getNodeContainers('heap-1');
+			expect(containers).toBeDefined();
+			expect(containers?.size).toBe(7);
+		});
+
+		it('returns undefined for unknown element', () => {
+			expect(renderer.getNodeContainers('nonexistent')).toBeUndefined();
+		});
+	});
+
+	describe('getNodePositions', () => {
+		it('returns positions after render', () => {
+			const element = makeElement({
+				nodes: MAX_HEAP as unknown as JsonValue[],
+			});
+			renderer.render(element);
+
+			const positions = renderer.getNodePositions('heap-1');
+			expect(positions).toBeDefined();
+			expect(positions?.size).toBe(7);
+		});
+
+		it('root is positioned above children', () => {
+			const element = makeElement({
+				nodes: MIN_HEAP as unknown as JsonValue[],
+			});
+			renderer.render(element);
+
+			const positions = renderer.getNodePositions('heap-1');
+			const rootPos = positions?.get(0);
+			const leftPos = positions?.get(1);
+			const rightPos = positions?.get(2);
+			expect(rootPos).toBeDefined();
+			expect(leftPos).toBeDefined();
+			expect(rightPos).toBeDefined();
+			expect(rootPos!.y).toBeLessThan(leftPos!.y);
+			expect(rootPos!.y).toBeLessThan(rightPos!.y);
+		});
+
+		it('returns undefined for unknown element', () => {
+			expect(renderer.getNodePositions('nonexistent')).toBeUndefined();
+		});
+	});
+
+	describe('getArrayCellContainers', () => {
+		it('returns array containers after render', () => {
+			const element = makeElement({
+				nodes: MIN_HEAP as unknown as JsonValue[],
+			});
+			renderer.render(element);
+
+			const cells = renderer.getArrayCellContainers('heap-1');
+			expect(cells).toBeDefined();
+			expect(cells?.size).toBe(3);
+		});
+
+		it('returns empty map when showArray is false', () => {
+			const element = makeElement({
+				nodes: MIN_HEAP as unknown as JsonValue[],
+				showArray: false,
+			});
+			renderer.render(element);
+
+			const cells = renderer.getArrayCellContainers('heap-1');
+			expect(cells).toBeDefined();
+			expect(cells?.size).toBe(0);
+		});
+
+		it('returns undefined for unknown element', () => {
+			expect(renderer.getArrayCellContainers('nonexistent')).toBeUndefined();
+		});
+	});
+});

--- a/src/lib/pixi/renderers/heap-renderer.ts
+++ b/src/lib/pixi/renderers/heap-renderer.ts
@@ -1,0 +1,351 @@
+/**
+ * Renderer for Heap composite elements.
+ *
+ * Provides a complete binary tree visualization with an array overlay below.
+ * Supports both min-heap and max-heap display. Shows parent-child index
+ * relationships and highlights corresponding positions in tree/array views.
+ *
+ * Node containers are stored for GSAP heapify and swap animations.
+ *
+ * Spec reference: Section 6.3.1 (Heap)
+ */
+
+import type { SceneElement } from '@/types';
+import { hexToPixiColor } from './shared';
+
+// ── Pixi.js DI interfaces ──
+
+interface PixiContainer {
+	addChild(...children: unknown[]): void;
+	removeChildren(): void;
+	destroy(options?: { children: boolean }): void;
+	position: { set(x: number, y: number): void; x: number; y: number };
+	alpha: number;
+	angle: number;
+	visible: boolean;
+	label: string;
+	cullable: boolean;
+	children: unknown[];
+}
+
+interface PixiGraphics {
+	clear(): PixiGraphics;
+	rect(x: number, y: number, w: number, h: number): PixiGraphics;
+	roundRect(x: number, y: number, w: number, h: number, r: number): PixiGraphics;
+	circle(x: number, y: number, r: number): PixiGraphics;
+	fill(opts: { color: number; alpha?: number } | number): PixiGraphics;
+	stroke(opts: { width: number; color: number; alpha?: number }): PixiGraphics;
+	moveTo(x: number, y: number): PixiGraphics;
+	lineTo(x: number, y: number): PixiGraphics;
+	bezierCurveTo(
+		cp1x: number,
+		cp1y: number,
+		cp2x: number,
+		cp2y: number,
+		x: number,
+		y: number,
+	): PixiGraphics;
+	poly(points: number[]): PixiGraphics;
+	closePath(): PixiGraphics;
+	destroy(): void;
+}
+
+interface PixiText {
+	text: string;
+	style: Record<string, unknown>;
+	anchor: { set(x: number, y: number): void };
+	position: { set(x: number, y: number): void };
+	visible: boolean;
+	destroy(): void;
+}
+
+interface PixiModule {
+	Container: new () => PixiContainer;
+	Graphics: new () => PixiGraphics;
+	Text: new (opts: { text: string; style: unknown }) => PixiText;
+	TextStyle: new (opts: Record<string, unknown>) => Record<string, unknown>;
+}
+
+// ── Heap Types ──
+
+export type HeapType = 'min' | 'max';
+
+export interface HeapNodeData {
+	index: number;
+	value: number;
+}
+
+interface NodePosition {
+	x: number;
+	y: number;
+}
+
+// ── Constants ──
+
+const ARRAY_CELL_SIZE = 32;
+const ARRAY_GAP = 4;
+
+/**
+ * Renderer for Heap composite elements.
+ */
+export class HeapRenderer {
+	private pixi: PixiModule;
+	private nodeContainers: Record<string, Map<number, PixiContainer>> = {};
+	private nodePositions: Record<string, Map<number, NodePosition>> = {};
+	private arrayCellContainers: Record<string, Map<number, PixiContainer>> = {};
+
+	constructor(pixi: PixiModule) {
+		this.pixi = pixi;
+	}
+
+	/**
+	 * Render a heap element with tree view and array overlay.
+	 */
+	render(element: SceneElement): PixiContainer {
+		const container = new this.pixi.Container();
+		const { style, metadata } = element;
+
+		const nodes = (metadata.nodes as unknown as HeapNodeData[]) ?? [];
+		const heapType = (metadata.heapType as HeapType) ?? 'max';
+		const nodeSize = (metadata.nodeSize as number) ?? 20;
+		const levelGap = (metadata.levelGap as number) ?? 60;
+		const showArray = (metadata.showArray as boolean) ?? true;
+		const showIndices = (metadata.showIndices as boolean) ?? true;
+		const highlightedIndices = (metadata.highlightedIndices as number[]) ?? [];
+		const swapIndices = (metadata.swapIndices as number[]) ?? [];
+
+		const nodeMap = new Map<number, PixiContainer>();
+		const posMap = new Map<number, NodePosition>();
+		const arrayMap = new Map<number, PixiContainer>();
+
+		if (nodes.length === 0) {
+			this.nodeContainers[element.id] = nodeMap;
+			this.nodePositions[element.id] = posMap;
+			this.arrayCellContainers[element.id] = arrayMap;
+			return container;
+		}
+
+		const fillColor = hexToPixiColor(style.fill);
+		const strokeColor = hexToPixiColor(style.stroke);
+
+		// Compute tree layout
+		const positions = this.computeTreeLayout(nodes.length, nodeSize, levelGap);
+		const highlightColor = hexToPixiColor('#3b82f6');
+		const swapColor = hexToPixiColor('#f97316');
+
+		// Heap type label
+		const typeStyle = new this.pixi.TextStyle({
+			fontSize: 10,
+			fontFamily: style.fontFamily,
+			fontWeight: '600',
+			fill: hexToPixiColor('#9ca3af'),
+		});
+		const typeText = new this.pixi.Text({
+			text: heapType === 'min' ? 'Min-Heap' : 'Max-Heap',
+			style: typeStyle,
+		});
+		typeText.anchor.set(0.5, 1);
+		typeText.position.set(element.size.width / 2, -4);
+		container.addChild(typeText);
+
+		// Pass 1: Draw edges
+		for (let i = 1; i < nodes.length; i++) {
+			const parentIdx = Math.floor((i - 1) / 2);
+			const parentPos = positions.get(parentIdx);
+			const childPos = positions.get(i);
+			if (!parentPos || !childPos) continue;
+
+			const edgeG = new this.pixi.Graphics();
+			edgeG.moveTo(parentPos.x, parentPos.y + nodeSize);
+			edgeG.lineTo(childPos.x, childPos.y - nodeSize);
+			edgeG.stroke({ width: style.strokeWidth, color: strokeColor, alpha: 0.5 });
+			container.addChild(edgeG);
+		}
+
+		// Pass 2: Draw tree nodes
+		for (const node of nodes) {
+			const pos = positions.get(node.index);
+			if (!pos) continue;
+
+			posMap.set(node.index, pos);
+			const isHighlighted = highlightedIndices.includes(node.index);
+			const isSwapping = swapIndices.includes(node.index);
+
+			const nodeColor = isSwapping ? swapColor : isHighlighted ? highlightColor : fillColor;
+
+			const g = new this.pixi.Graphics();
+			g.circle(pos.x, pos.y, nodeSize);
+			g.fill({ color: nodeColor });
+			g.stroke({ width: style.strokeWidth, color: strokeColor });
+			container.addChild(g);
+
+			// Value text
+			const textStyle = new this.pixi.TextStyle({
+				fontSize: style.fontSize,
+				fontFamily: style.fontFamily,
+				fontWeight: String(style.fontWeight),
+				fill: hexToPixiColor(style.textColor),
+			});
+			const valueText = new this.pixi.Text({
+				text: String(node.value),
+				style: textStyle,
+			});
+			valueText.anchor.set(0.5, 0.5);
+			valueText.position.set(pos.x, pos.y);
+			container.addChild(valueText);
+
+			// Index label below node
+			if (showIndices) {
+				const idxStyle = new this.pixi.TextStyle({
+					fontSize: 8,
+					fontFamily: style.fontFamily,
+					fontWeight: '400',
+					fill: hexToPixiColor('#9ca3af'),
+				});
+				const idxText = new this.pixi.Text({
+					text: String(node.index),
+					style: idxStyle,
+				});
+				idxText.anchor.set(0.5, 0);
+				idxText.position.set(pos.x, pos.y + nodeSize + 2);
+				container.addChild(idxText);
+			}
+
+			nodeMap.set(node.index, container);
+		}
+
+		// Pass 3: Array overlay
+		if (showArray) {
+			const treeHeight = this.getTreeHeight(nodes.length);
+			const arrayY = (treeHeight + 1) * levelGap + nodeSize + 30;
+			const totalWidth = nodes.length * (ARRAY_CELL_SIZE + ARRAY_GAP) - ARRAY_GAP;
+			const startX = (element.size.width - totalWidth) / 2;
+
+			// "Array:" label
+			const arrayLabelStyle = new this.pixi.TextStyle({
+				fontSize: 9,
+				fontFamily: style.fontFamily,
+				fontWeight: '600',
+				fill: hexToPixiColor('#9ca3af'),
+			});
+			const arrayLabel = new this.pixi.Text({
+				text: 'Array:',
+				style: arrayLabelStyle,
+			});
+			arrayLabel.anchor.set(1, 0.5);
+			arrayLabel.position.set(startX - 8, arrayY + ARRAY_CELL_SIZE / 2);
+			container.addChild(arrayLabel);
+
+			for (const node of nodes) {
+				const cellX = startX + node.index * (ARRAY_CELL_SIZE + ARRAY_GAP);
+				const isHighlighted = highlightedIndices.includes(node.index);
+				const isSwapping = swapIndices.includes(node.index);
+				const cellColor = isSwapping ? swapColor : isHighlighted ? highlightColor : fillColor;
+
+				const cellG = new this.pixi.Graphics();
+				cellG.rect(cellX, arrayY, ARRAY_CELL_SIZE, ARRAY_CELL_SIZE);
+				cellG.fill({ color: cellColor, alpha: 0.8 });
+				cellG.stroke({ width: 1, color: strokeColor });
+				container.addChild(cellG);
+
+				// Value in cell
+				const cellTextStyle = new this.pixi.TextStyle({
+					fontSize: 10,
+					fontFamily: style.fontFamily,
+					fontWeight: '600',
+					fill: hexToPixiColor(style.textColor),
+				});
+				const cellText = new this.pixi.Text({
+					text: String(node.value),
+					style: cellTextStyle,
+				});
+				cellText.anchor.set(0.5, 0.5);
+				cellText.position.set(cellX + ARRAY_CELL_SIZE / 2, arrayY + ARRAY_CELL_SIZE / 2);
+				container.addChild(cellText);
+
+				// Index below cell
+				const cellIdxStyle = new this.pixi.TextStyle({
+					fontSize: 7,
+					fontFamily: style.fontFamily,
+					fontWeight: '400',
+					fill: hexToPixiColor('#6b7280'),
+				});
+				const cellIdx = new this.pixi.Text({
+					text: String(node.index),
+					style: cellIdxStyle,
+				});
+				cellIdx.anchor.set(0.5, 0);
+				cellIdx.position.set(cellX + ARRAY_CELL_SIZE / 2, arrayY + ARRAY_CELL_SIZE + 2);
+				container.addChild(cellIdx);
+
+				arrayMap.set(node.index, container);
+			}
+		}
+
+		this.nodeContainers[element.id] = nodeMap;
+		this.nodePositions[element.id] = posMap;
+		this.arrayCellContainers[element.id] = arrayMap;
+		return container;
+	}
+
+	/**
+	 * Get tree node containers for animation targeting.
+	 */
+	getNodeContainers(elementId: string): Map<number, PixiContainer> | undefined {
+		return this.nodeContainers[elementId];
+	}
+
+	/**
+	 * Get computed tree node positions for animation.
+	 */
+	getNodePositions(elementId: string): Map<number, NodePosition> | undefined {
+		return this.nodePositions[elementId];
+	}
+
+	/**
+	 * Get array cell containers for animation targeting.
+	 */
+	getArrayCellContainers(elementId: string): Map<number, PixiContainer> | undefined {
+		return this.arrayCellContainers[elementId];
+	}
+
+	/**
+	 * Compute tree height from node count (0-indexed levels).
+	 */
+	private getTreeHeight(count: number): number {
+		if (count <= 0) return 0;
+		return Math.floor(Math.log2(count));
+	}
+
+	/**
+	 * Compute complete binary tree layout using index-based positioning.
+	 * Each level has 2^level nodes, positioned evenly.
+	 */
+	private computeTreeLayout(
+		count: number,
+		nodeSize: number,
+		levelGap: number,
+	): Map<number, NodePosition> {
+		const positions = new Map<number, NodePosition>();
+		const height = this.getTreeHeight(count);
+		const maxWidth = 2 ** height;
+		const spacing = nodeSize * 2.5;
+
+		for (let i = 0; i < count; i++) {
+			const level = Math.floor(Math.log2(i + 1));
+			const levelStart = 2 ** level - 1;
+			const posInLevel = i - levelStart;
+			const nodesInLevel = 2 ** level;
+
+			// Center nodes within the widest level span
+			const levelWidth = maxWidth * spacing;
+			const cellWidth = levelWidth / nodesInLevel;
+			const x = cellWidth * posInLevel + cellWidth / 2;
+			const y = level * levelGap + nodeSize;
+
+			positions.set(i, { x, y });
+		}
+
+		return positions;
+	}
+}


### PR DESCRIPTION
## Summary
- Add `HeapRenderer` with complete binary tree visualization and array overlay below
- Supports min-heap/max-heap type labels, index labels, highlight and swap indicators
- Add 5 GSAP animation presets: `heapSiftUp`, `heapSiftDown`, `heapExtract`, `heapBuildFloyd`, `heapArrayTreeSync`
- 35 new tests (17 renderer + 18 presets), 1224 total suite passing

## Test plan
- [x] Empty heap renders without errors
- [x] Max-heap/min-heap type labels render correctly
- [x] Node values rendered in tree view
- [x] Edges drawn between parent-child nodes
- [x] Array overlay with "Array:" label renders by default
- [x] Array hidden when `showArray: false`
- [x] Index labels visible when `showIndices: true`
- [x] Array cells render as rectangles
- [x] Root positioned above children in tree layout
- [x] Node/array containers accessible for GSAP targeting
- [x] All 5 GSAP presets return valid timelines
- [x] Extract duration > sift-down duration
- [x] Duration scales with path/node count
- [x] Quality gate: biome ✓ tsc ✓ vitest ✓

Closes #47

🤖 Generated with [Claude Code](https://claude.com/claude-code)