### PR TITLE
feat: implement Hash Table composite with collision and chaining animations (#49)

### DIFF
--- a/src/lib/gsap/presets/hash-table-presets.test.ts
+++ b/src/lib/gsap/presets/hash-table-presets.test.ts
@@ -1,0 +1,158 @@
+/**
+ * Tests for Hash Table GSAP animation presets.
+ */
+
+import gsap from 'gsap';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+	hashCompute,
+	hashDelete,
+	hashInsert,
+	hashInsertCollision,
+	hashResize,
+	hashSearch,
+} from './hash-table-presets';
+
+interface MockNode {
+	alpha: number;
+	_fillColor: number;
+}
+
+function makeNode(): MockNode {
+	return { alpha: 0.8, _fillColor: 0x2a2a4a };
+}
+
+describe('Hash Table Animation Presets', () => {
+	beforeEach(() => {
+		gsap.ticker.lagSmoothing(0);
+	});
+
+	describe('hashCompute', () => {
+		it('returns a GSAP timeline', () => {
+			const tl = hashCompute(makeNode(), 0xfbbf24, 0x3b82f6);
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+		});
+
+		it('has positive duration', () => {
+			const tl = hashCompute(makeNode(), 0xfbbf24, 0x3b82f6);
+			expect(tl.duration()).toBeGreaterThan(0);
+		});
+	});
+
+	describe('hashInsert', () => {
+		it('returns a GSAP timeline', () => {
+			const tl = hashInsert(makeNode(), makeNode(), 0x3b82f6, 0x4ade80);
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+		});
+
+		it('has positive duration', () => {
+			const tl = hashInsert(makeNode(), makeNode(), 0x3b82f6, 0x4ade80);
+			expect(tl.duration()).toBeGreaterThan(0);
+		});
+	});
+
+	describe('hashInsertCollision', () => {
+		it('returns a GSAP timeline', () => {
+			const tl = hashInsertCollision(makeNode(), [makeNode()], makeNode(), 0xf97316, 0x4ade80);
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+		});
+
+		it('has positive duration', () => {
+			const tl = hashInsertCollision(
+				makeNode(),
+				[makeNode(), makeNode()],
+				makeNode(),
+				0xf97316,
+				0x4ade80,
+			);
+			expect(tl.duration()).toBeGreaterThan(0);
+		});
+
+		it('has longer duration than simple insert', () => {
+			const simple = hashInsert(makeNode(), makeNode(), 0x3b82f6, 0x4ade80);
+			const collision = hashInsertCollision(
+				makeNode(),
+				[makeNode()],
+				makeNode(),
+				0xf97316,
+				0x4ade80,
+			);
+			expect(collision.duration()).toBeGreaterThan(simple.duration());
+		});
+	});
+
+	describe('hashSearch', () => {
+		it('returns a GSAP timeline', () => {
+			const tl = hashSearch(makeNode(), [makeNode(), makeNode()], makeNode(), 0x3b82f6, 0x4ade80);
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+		});
+
+		it('has positive duration', () => {
+			const tl = hashSearch(makeNode(), [makeNode()], makeNode(), 0x3b82f6, 0x4ade80);
+			expect(tl.duration()).toBeGreaterThan(0);
+		});
+
+		it('works with not-found (null)', () => {
+			const tl = hashSearch(makeNode(), [makeNode()], null, 0x3b82f6, 0x4ade80);
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+			expect(tl.duration()).toBeGreaterThan(0);
+		});
+
+		it('longer chain means longer duration', () => {
+			const short = hashSearch(makeNode(), [makeNode()], makeNode(), 0x3b82f6, 0x4ade80);
+			const long = hashSearch(
+				makeNode(),
+				[makeNode(), makeNode(), makeNode(), makeNode()],
+				makeNode(),
+				0x3b82f6,
+				0x4ade80,
+			);
+			expect(long.duration()).toBeGreaterThan(short.duration());
+		});
+	});
+
+	describe('hashDelete', () => {
+		it('returns a GSAP timeline', () => {
+			const tl = hashDelete(makeNode(), [makeNode()], makeNode(), 0x3b82f6, 0xef4444);
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+		});
+
+		it('has positive duration', () => {
+			const tl = hashDelete(makeNode(), [makeNode()], makeNode(), 0x3b82f6, 0xef4444);
+			expect(tl.duration()).toBeGreaterThan(0);
+		});
+	});
+
+	describe('hashResize', () => {
+		it('returns a GSAP timeline', () => {
+			const tl = hashResize(
+				[makeNode(), makeNode()],
+				[makeNode(), makeNode(), makeNode(), makeNode()],
+				0xfbbf24,
+				0x2a2a4a,
+			);
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+		});
+
+		it('has positive duration', () => {
+			const tl = hashResize([makeNode()], [makeNode(), makeNode()], 0xfbbf24, 0x2a2a4a);
+			expect(tl.duration()).toBeGreaterThan(0);
+		});
+
+		it('handles empty old entries', () => {
+			const tl = hashResize([], [makeNode(), makeNode()], 0xfbbf24, 0x2a2a4a);
+			expect(tl.duration()).toBeGreaterThan(0);
+		});
+
+		it('more entries means longer duration', () => {
+			const small = hashResize([makeNode()], [makeNode()], 0xfbbf24, 0x2a2a4a);
+			const large = hashResize(
+				[makeNode(), makeNode(), makeNode(), makeNode()],
+				[makeNode(), makeNode(), makeNode(), makeNode()],
+				0xfbbf24,
+				0x2a2a4a,
+			);
+			expect(large.duration()).toBeGreaterThan(small.duration());
+		});
+	});
+});

--- a/src/lib/gsap/presets/hash-table-presets.ts
+++ b/src/lib/gsap/presets/hash-table-presets.ts
@@ -1,0 +1,221 @@
+/**
+ * GSAP animation presets for Hash Table composite.
+ *
+ * Provides hash table-specific animations:
+ * - Hash computation (key → index)
+ * - Insert (direct + collision with chaining)
+ * - Search (hash → bucket → chain traversal)
+ * - Delete (find and remove from chain)
+ * - Resize/Rehash (table expansion)
+ *
+ * Spec reference: Section 6.3.1 (Hash Table), Section 9.3 (Animation Presets)
+ */
+
+import gsap from 'gsap';
+
+interface AnimatableNode {
+	alpha: number;
+	_fillColor?: number;
+}
+
+// ── Hash Computation ──
+
+/**
+ * Hash computation animation — highlights the bucket being targeted.
+ * Shows the key being "hashed" into an index.
+ */
+export function hashCompute(
+	bucket: AnimatableNode,
+	computeColor: number,
+	resultColor: number,
+): gsap.core.Timeline {
+	const tl = gsap.timeline();
+
+	// Flash compute
+	tl.to(bucket, { _fillColor: computeColor, alpha: 1, duration: 0.15 }, 0);
+	// Settle to result
+	tl.to(bucket, { _fillColor: resultColor, alpha: 1, duration: 0.2 }, 0.2);
+	tl.to(bucket, { alpha: 0.8, duration: 0.1 }, 0.45);
+
+	return tl;
+}
+
+// ── Insert ──
+
+/**
+ * Insert without collision — direct placement into bucket.
+ */
+export function hashInsert(
+	bucket: AnimatableNode,
+	entry: AnimatableNode,
+	bucketColor: number,
+	insertColor: number,
+): gsap.core.Timeline {
+	const tl = gsap.timeline();
+
+	// Step 1: Highlight bucket
+	tl.to(bucket, { _fillColor: bucketColor, alpha: 1, duration: 0.15 }, 0);
+
+	// Step 2: Entry fades in
+	tl.fromTo(
+		entry,
+		{ alpha: 0, _fillColor: insertColor },
+		{ alpha: 1, duration: 0.2, ease: 'back.out' },
+		0.2,
+	);
+
+	// Step 3: Settle
+	tl.to(bucket, { alpha: 0.8, duration: 0.1 }, 0.45);
+
+	return tl;
+}
+
+/**
+ * Insert with collision — shows collision indicator, then chains.
+ */
+export function hashInsertCollision(
+	bucket: AnimatableNode,
+	existingEntries: AnimatableNode[],
+	newEntry: AnimatableNode,
+	collisionColor: number,
+	chainColor: number,
+): gsap.core.Timeline {
+	const tl = gsap.timeline();
+
+	// Step 1: Highlight bucket + collision flash
+	tl.to(bucket, { _fillColor: collisionColor, alpha: 1, duration: 0.15 }, 0);
+
+	// Step 2: Flash existing entries
+	for (const entry of existingEntries) {
+		tl.to(entry, { _fillColor: collisionColor, alpha: 1, duration: 0.1 }, 0.15);
+		tl.to(entry, { alpha: 0.8, duration: 0.08 }, 0.28);
+	}
+
+	// Step 3: Chain new entry
+	tl.fromTo(
+		newEntry,
+		{ alpha: 0, _fillColor: chainColor },
+		{ alpha: 1, duration: 0.2, ease: 'back.out' },
+		0.35,
+	);
+
+	// Step 4: Settle
+	tl.to(bucket, { alpha: 0.8, duration: 0.1 }, 0.6);
+
+	return tl;
+}
+
+// ── Search ──
+
+/**
+ * Search animation — hash to bucket, then traverse chain.
+ */
+export function hashSearch(
+	bucket: AnimatableNode,
+	chainEntries: AnimatableNode[],
+	foundEntry: AnimatableNode | null,
+	searchColor: number,
+	foundColor: number,
+): gsap.core.Timeline {
+	const tl = gsap.timeline();
+
+	// Step 1: Highlight bucket
+	tl.to(bucket, { _fillColor: searchColor, alpha: 1, duration: 0.15 }, 0);
+
+	// Step 2: Traverse chain
+	for (let i = 0; i < chainEntries.length; i++) {
+		const entry = chainEntries[i];
+		const originalColor = entry._fillColor ?? 0x2a2a4a;
+		tl.to(entry, { _fillColor: searchColor, alpha: 1, duration: 0.1 }, 0.2 + i * 0.15);
+		tl.to(entry, { _fillColor: originalColor, alpha: 0.8, duration: 0.08 }, 0.32 + i * 0.15);
+	}
+
+	// Step 3: Highlight found entry
+	if (foundEntry) {
+		const foundOffset = 0.2 + chainEntries.length * 0.15 + 0.05;
+		tl.to(foundEntry, { _fillColor: foundColor, alpha: 1, duration: 0.15 }, foundOffset);
+		tl.to(foundEntry, { alpha: 0.8, duration: 0.1 }, foundOffset + 0.2);
+	}
+
+	// Settle bucket
+	tl.to(bucket, { alpha: 0.8, duration: 0.1 }, 0.2 + chainEntries.length * 0.15 + 0.3);
+
+	return tl;
+}
+
+// ── Delete ──
+
+/**
+ * Delete animation — find entry in chain, then remove it.
+ */
+export function hashDelete(
+	bucket: AnimatableNode,
+	chainEntries: AnimatableNode[],
+	deletedEntry: AnimatableNode,
+	searchColor: number,
+	deleteColor: number,
+): gsap.core.Timeline {
+	const tl = gsap.timeline();
+
+	// Step 1: Hash to bucket
+	tl.to(bucket, { _fillColor: searchColor, alpha: 1, duration: 0.12 }, 0);
+
+	// Step 2: Traverse chain
+	for (let i = 0; i < chainEntries.length; i++) {
+		const entry = chainEntries[i];
+		tl.to(entry, { _fillColor: searchColor, alpha: 1, duration: 0.1 }, 0.15 + i * 0.12);
+	}
+
+	// Step 3: Highlight + remove deleted entry
+	const removeOffset = 0.15 + chainEntries.length * 0.12 + 0.05;
+	tl.to(deletedEntry, { _fillColor: deleteColor, alpha: 1, duration: 0.12 }, removeOffset);
+	tl.to(deletedEntry, { alpha: 0, duration: 0.2, ease: 'power2.in' }, removeOffset + 0.15);
+
+	// Settle
+	tl.to(bucket, { alpha: 0.8, duration: 0.1 }, removeOffset + 0.4);
+
+	return tl;
+}
+
+// ── Resize/Rehash ──
+
+/**
+ * Resize animation — old entries fade, new buckets appear,
+ * entries rehash into new positions.
+ */
+export function hashResize(
+	oldEntries: AnimatableNode[],
+	newBuckets: AnimatableNode[],
+	rehashColor: number,
+	settleColor: number,
+): gsap.core.Timeline {
+	const tl = gsap.timeline();
+
+	// Step 1: Flash old entries
+	for (let i = 0; i < oldEntries.length; i++) {
+		tl.to(oldEntries[i], { _fillColor: rehashColor, alpha: 1, duration: 0.1 }, i * 0.05);
+	}
+
+	// Step 2: New buckets appear
+	const flashDuration = oldEntries.length * 0.05 + 0.15;
+	for (let i = 0; i < newBuckets.length; i++) {
+		tl.fromTo(
+			newBuckets[i],
+			{ alpha: 0 },
+			{ alpha: 0.8, duration: 0.15 },
+			flashDuration + i * 0.05,
+		);
+	}
+
+	// Step 3: Entries settle into new positions
+	const newBucketDuration = flashDuration + newBuckets.length * 0.05 + 0.1;
+	for (let i = 0; i < oldEntries.length; i++) {
+		tl.to(
+			oldEntries[i],
+			{ _fillColor: settleColor, alpha: 0.8, duration: 0.15 },
+			newBucketDuration + i * 0.08,
+		);
+	}
+
+	return tl;
+}

--- a/src/lib/pixi/renderers/hash-table-renderer.test.ts
+++ b/src/lib/pixi/renderers/hash-table-renderer.test.ts
@@ -1,0 +1,273 @@
+/**
+ * Tests for HashTableRenderer — Hash Table composite visualization.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { JsonValue, SceneElement } from '@/types';
+import { type HashBucket, HashTableRenderer } from './hash-table-renderer';
+import { DEFAULT_ELEMENT_STYLE } from './shared';
+
+function createMockPixi() {
+	function MockContainer(this: Record<string, unknown>) {
+		const children: unknown[] = [];
+		this.addChild = vi.fn((...args: unknown[]) => children.push(...args));
+		this.removeChildren = vi.fn();
+		this.destroy = vi.fn();
+		this.position = { set: vi.fn(), x: 0, y: 0 };
+		this.alpha = 1;
+		this.angle = 0;
+		this.visible = true;
+		this.label = '';
+		this.cullable = false;
+		this.children = children;
+	}
+
+	function MockGraphics(this: Record<string, unknown>) {
+		this.clear = vi.fn().mockReturnThis();
+		this.rect = vi.fn().mockReturnThis();
+		this.roundRect = vi.fn().mockReturnThis();
+		this.circle = vi.fn().mockReturnThis();
+		this.fill = vi.fn().mockReturnThis();
+		this.stroke = vi.fn().mockReturnThis();
+		this.moveTo = vi.fn().mockReturnThis();
+		this.lineTo = vi.fn().mockReturnThis();
+		this.bezierCurveTo = vi.fn().mockReturnThis();
+		this.poly = vi.fn().mockReturnThis();
+		this.closePath = vi.fn().mockReturnThis();
+		this.destroy = vi.fn();
+	}
+
+	function MockText(this: Record<string, unknown>, opts: { text: string; style: unknown }) {
+		this.text = opts.text;
+		this.style = opts.style;
+		this.anchor = { set: vi.fn() };
+		this.position = { set: vi.fn() };
+		this.visible = true;
+		this.destroy = vi.fn();
+	}
+
+	function MockTextStyle(_opts: Record<string, unknown>) {
+		return { ..._opts };
+	}
+
+	return {
+		Container: vi.fn().mockImplementation(MockContainer),
+		Graphics: vi.fn().mockImplementation(MockGraphics),
+		Text: vi.fn().mockImplementation(MockText),
+		TextStyle: vi.fn().mockImplementation(MockTextStyle),
+	};
+}
+
+function makeElement(metadata: Record<string, JsonValue> = {}): SceneElement {
+	return {
+		id: 'ht-1',
+		type: 'register',
+		position: { x: 0, y: 0 },
+		size: { width: 500, height: 400 },
+		rotation: 0,
+		opacity: 1,
+		visible: true,
+		locked: false,
+		style: DEFAULT_ELEMENT_STYLE,
+		metadata,
+	};
+}
+
+const SIMPLE_TABLE: HashBucket[] = [
+	{
+		index: 0,
+		entries: [{ key: 'a', value: '1', bucketIndex: 0, chainPosition: 0 }],
+		hasCollision: false,
+	},
+	{ index: 1, entries: [], hasCollision: false },
+	{
+		index: 2,
+		entries: [
+			{ key: 'b', value: '2', bucketIndex: 2, chainPosition: 0 },
+			{ key: 'c', value: '3', bucketIndex: 2, chainPosition: 1 },
+		],
+		hasCollision: true,
+	},
+	{ index: 3, entries: [], hasCollision: false },
+];
+
+describe('HashTableRenderer', () => {
+	let renderer: HashTableRenderer;
+	let pixi: ReturnType<typeof createMockPixi>;
+
+	beforeEach(() => {
+		pixi = createMockPixi();
+		renderer = new HashTableRenderer(pixi as never);
+	});
+
+	describe('render', () => {
+		it('creates a container for empty table', () => {
+			const element = makeElement({ tableSize: 0 });
+			const container = renderer.render(element);
+			expect(container).toBeDefined();
+		});
+
+		it('renders bucket indices', () => {
+			const element = makeElement({
+				buckets: SIMPLE_TABLE as unknown as JsonValue[],
+				tableSize: 4,
+			});
+			renderer.render(element);
+
+			const textCalls = pixi.Text.mock.calls;
+			const indices = textCalls
+				.map((c: unknown[]) => (c[0] as { text: string }).text)
+				.filter((t: string) => ['0', '1', '2', '3'].includes(t));
+			expect(indices).toContain('0');
+			expect(indices).toContain('1');
+			expect(indices).toContain('2');
+			expect(indices).toContain('3');
+		});
+
+		it('renders entry keys', () => {
+			const element = makeElement({
+				buckets: SIMPLE_TABLE as unknown as JsonValue[],
+				tableSize: 4,
+			});
+			renderer.render(element);
+
+			const textCalls = pixi.Text.mock.calls;
+			const keys = textCalls
+				.map((c: unknown[]) => (c[0] as { text: string }).text)
+				.filter((t: string) => ['a', 'b', 'c'].includes(t));
+			expect(keys).toContain('a');
+			expect(keys).toContain('b');
+			expect(keys).toContain('c');
+		});
+
+		it('renders hash function label', () => {
+			const element = makeElement({
+				buckets: [] as JsonValue[],
+				tableSize: 4,
+				hashFunction: 'key % 4',
+			});
+			renderer.render(element);
+
+			const textCalls = pixi.Text.mock.calls;
+			const fnLabel = textCalls.find(
+				(c: unknown[]) => (c[0] as { text: string }).text === 'h(k) = key % 4',
+			);
+			expect(fnLabel).toBeDefined();
+		});
+
+		it('renders collision indicator', () => {
+			const element = makeElement({
+				buckets: SIMPLE_TABLE as unknown as JsonValue[],
+				tableSize: 4,
+			});
+			renderer.render(element);
+
+			// Collision indicator is a small filled circle
+			const graphicsResults = pixi.Graphics.mock.results;
+			const hasSmallCircle = graphicsResults.some((r: { type: string; value?: unknown }) => {
+				const v = r.value as Record<string, { mock: { calls: unknown[][] } }> | undefined;
+				const circleCalls = v?.circle?.mock?.calls ?? [];
+				return circleCalls.some((call: unknown[]) => (call[2] as number) === 3);
+			});
+			expect(hasSmallCircle).toBe(true);
+		});
+
+		it('renders load factor by default', () => {
+			const element = makeElement({
+				buckets: SIMPLE_TABLE as unknown as JsonValue[],
+				tableSize: 4,
+			});
+			renderer.render(element);
+
+			const textCalls = pixi.Text.mock.calls;
+			const lfText = textCalls.find((c: unknown[]) =>
+				(c[0] as { text: string }).text.startsWith('Load factor:'),
+			);
+			expect(lfText).toBeDefined();
+		});
+
+		it('hides load factor when showLoadFactor is false', () => {
+			const element = makeElement({
+				buckets: SIMPLE_TABLE as unknown as JsonValue[],
+				tableSize: 4,
+				showLoadFactor: false,
+			});
+			renderer.render(element);
+
+			const textCalls = pixi.Text.mock.calls;
+			const lfText = textCalls.find((c: unknown[]) =>
+				(c[0] as { text: string }).text.startsWith('Load factor:'),
+			);
+			expect(lfText).toBeUndefined();
+		});
+
+		it('renders chain nodes as rounded rectangles', () => {
+			const element = makeElement({
+				buckets: SIMPLE_TABLE as unknown as JsonValue[],
+				tableSize: 4,
+			});
+			renderer.render(element);
+
+			const graphicsResults = pixi.Graphics.mock.results;
+			const hasRoundRect = graphicsResults.some((r: { type: string; value?: unknown }) => {
+				const v = r.value as Record<string, { mock: { calls: unknown[][] } }> | undefined;
+				return (v?.roundRect?.mock?.calls?.length ?? 0) > 0;
+			});
+			expect(hasRoundRect).toBe(true);
+		});
+	});
+
+	describe('getBucketContainers', () => {
+		it('returns containers after render', () => {
+			const element = makeElement({
+				buckets: SIMPLE_TABLE as unknown as JsonValue[],
+				tableSize: 4,
+			});
+			renderer.render(element);
+
+			const containers = renderer.getBucketContainers('ht-1');
+			expect(containers).toBeDefined();
+			expect(containers?.size).toBe(4);
+		});
+
+		it('returns undefined for unknown element', () => {
+			expect(renderer.getBucketContainers('nonexistent')).toBeUndefined();
+		});
+	});
+
+	describe('getEntryContainers', () => {
+		it('returns entry containers after render', () => {
+			const element = makeElement({
+				buckets: SIMPLE_TABLE as unknown as JsonValue[],
+				tableSize: 4,
+			});
+			renderer.render(element);
+
+			const entries = renderer.getEntryContainers('ht-1');
+			expect(entries).toBeDefined();
+			expect(entries?.size).toBe(3); // a, b, c
+		});
+
+		it('returns undefined for unknown element', () => {
+			expect(renderer.getEntryContainers('nonexistent')).toBeUndefined();
+		});
+	});
+
+	describe('getEntryPositions', () => {
+		it('returns positions after render', () => {
+			const element = makeElement({
+				buckets: SIMPLE_TABLE as unknown as JsonValue[],
+				tableSize: 4,
+			});
+			renderer.render(element);
+
+			const positions = renderer.getEntryPositions('ht-1');
+			expect(positions).toBeDefined();
+			expect(positions?.size).toBe(3);
+		});
+
+		it('returns undefined for unknown element', () => {
+			expect(renderer.getEntryPositions('nonexistent')).toBeUndefined();
+		});
+	});
+});

--- a/src/lib/pixi/renderers/hash-table-renderer.ts
+++ b/src/lib/pixi/renderers/hash-table-renderer.ts
@@ -1,0 +1,321 @@
+/**
+ * Renderer for Hash Table composite elements.
+ *
+ * Visualizes a hash table with vertical bucket array and horizontal
+ * chaining for collision resolution. Shows hash function computation
+ * (key → index) and collision indicators.
+ *
+ * Bucket and chain node containers are stored for GSAP animations.
+ *
+ * Spec reference: Section 6.3.1 (Hash Table)
+ */
+
+import type { SceneElement } from '@/types';
+import { hexToPixiColor } from './shared';
+
+// ── Pixi.js DI interfaces ──
+
+interface PixiContainer {
+	addChild(...children: unknown[]): void;
+	removeChildren(): void;
+	destroy(options?: { children: boolean }): void;
+	position: { set(x: number, y: number): void; x: number; y: number };
+	alpha: number;
+	angle: number;
+	visible: boolean;
+	label: string;
+	cullable: boolean;
+	children: unknown[];
+}
+
+interface PixiGraphics {
+	clear(): PixiGraphics;
+	rect(x: number, y: number, w: number, h: number): PixiGraphics;
+	roundRect(x: number, y: number, w: number, h: number, r: number): PixiGraphics;
+	circle(x: number, y: number, r: number): PixiGraphics;
+	fill(opts: { color: number; alpha?: number } | number): PixiGraphics;
+	stroke(opts: { width: number; color: number; alpha?: number }): PixiGraphics;
+	moveTo(x: number, y: number): PixiGraphics;
+	lineTo(x: number, y: number): PixiGraphics;
+	bezierCurveTo(
+		cp1x: number,
+		cp1y: number,
+		cp2x: number,
+		cp2y: number,
+		x: number,
+		y: number,
+	): PixiGraphics;
+	poly(points: number[]): PixiGraphics;
+	closePath(): PixiGraphics;
+	destroy(): void;
+}
+
+interface PixiText {
+	text: string;
+	style: Record<string, unknown>;
+	anchor: { set(x: number, y: number): void };
+	position: { set(x: number, y: number): void };
+	visible: boolean;
+	destroy(): void;
+}
+
+interface PixiModule {
+	Container: new () => PixiContainer;
+	Graphics: new () => PixiGraphics;
+	Text: new (opts: { text: string; style: unknown }) => PixiText;
+	TextStyle: new (opts: Record<string, unknown>) => Record<string, unknown>;
+}
+
+// ── Hash Table Types ──
+
+export interface HashEntry {
+	key: string;
+	value: string;
+	bucketIndex: number;
+	chainPosition: number;
+}
+
+export interface HashBucket {
+	index: number;
+	entries: HashEntry[];
+	hasCollision: boolean;
+}
+
+interface NodePosition {
+	x: number;
+	y: number;
+}
+
+// ── Constants ──
+
+const BUCKET_WIDTH = 50;
+const BUCKET_HEIGHT = 36;
+const CHAIN_NODE_SIZE = 32;
+const CHAIN_GAP = 12;
+const COLLISION_COLOR = '#f97316';
+const BUCKET_LABEL_COLOR = '#9ca3af';
+
+/**
+ * Renderer for Hash Table composite elements.
+ */
+export class HashTableRenderer {
+	private pixi: PixiModule;
+	private bucketContainers: Record<string, Map<number, PixiContainer>> = {};
+	private entryContainers: Record<string, Map<string, PixiContainer>> = {};
+	private entryPositions: Record<string, Map<string, NodePosition>> = {};
+
+	constructor(pixi: PixiModule) {
+		this.pixi = pixi;
+	}
+
+	/**
+	 * Render a hash table element.
+	 */
+	render(element: SceneElement): PixiContainer {
+		const container = new this.pixi.Container();
+		const { style, metadata } = element;
+
+		const buckets = (metadata.buckets as unknown as HashBucket[]) ?? [];
+		const tableSize = (metadata.tableSize as number) ?? buckets.length;
+		const hashFunction = (metadata.hashFunction as string) ?? '';
+		const highlightedBucket = (metadata.highlightedBucket as number) ?? -1;
+		const highlightedKey = (metadata.highlightedKey as string) ?? '';
+		const showLoadFactor = (metadata.showLoadFactor as boolean) ?? true;
+
+		const bucketMap = new Map<number, PixiContainer>();
+		const entryMap = new Map<string, PixiContainer>();
+		const posMap = new Map<string, NodePosition>();
+
+		if (tableSize === 0) {
+			this.bucketContainers[element.id] = bucketMap;
+			this.entryContainers[element.id] = entryMap;
+			this.entryPositions[element.id] = posMap;
+			return container;
+		}
+
+		const fillColor = hexToPixiColor(style.fill);
+		const strokeColor = hexToPixiColor(style.stroke);
+		const highlightColor = hexToPixiColor('#3b82f6');
+		const collisionPixi = hexToPixiColor(COLLISION_COLOR);
+
+		const bucketIndexSet = new Map<number, HashBucket>();
+		for (const bucket of buckets) {
+			bucketIndexSet.set(bucket.index, bucket);
+		}
+
+		// Hash function label
+		if (hashFunction) {
+			const fnStyle = new this.pixi.TextStyle({
+				fontSize: 10,
+				fontFamily: style.fontFamily,
+				fontWeight: '600',
+				fill: hexToPixiColor('#e5e7eb'),
+			});
+			const fnText = new this.pixi.Text({
+				text: `h(k) = ${hashFunction}`,
+				style: fnStyle,
+			});
+			fnText.anchor.set(0, 1);
+			fnText.position.set(0, -8);
+			container.addChild(fnText);
+		}
+
+		// Draw buckets
+		for (let i = 0; i < tableSize; i++) {
+			const y = i * (BUCKET_HEIGHT + 4);
+			const isHighlighted = i === highlightedBucket;
+			const bucket = bucketIndexSet.get(i);
+
+			// Bucket rectangle
+			const bucketG = new this.pixi.Graphics();
+			bucketG.rect(0, y, BUCKET_WIDTH, BUCKET_HEIGHT);
+			const bucketColor = isHighlighted ? highlightColor : fillColor;
+			bucketG.fill({ color: bucketColor, alpha: 0.8 });
+			bucketG.stroke({ width: style.strokeWidth, color: strokeColor });
+			container.addChild(bucketG);
+
+			// Bucket index label
+			const idxStyle = new this.pixi.TextStyle({
+				fontSize: 9,
+				fontFamily: style.fontFamily,
+				fontWeight: '600',
+				fill: hexToPixiColor(BUCKET_LABEL_COLOR),
+			});
+			const idxText = new this.pixi.Text({
+				text: String(i),
+				style: idxStyle,
+			});
+			idxText.anchor.set(1, 0.5);
+			idxText.position.set(-6, y + BUCKET_HEIGHT / 2);
+			container.addChild(idxText);
+
+			// Collision indicator
+			if (bucket?.hasCollision) {
+				const collG = new this.pixi.Graphics();
+				collG.circle(BUCKET_WIDTH - 6, y + 6, 3);
+				collG.fill({ color: collisionPixi });
+				container.addChild(collG);
+			}
+
+			bucketMap.set(i, container);
+
+			// Chain entries
+			if (bucket) {
+				for (let j = 0; j < bucket.entries.length; j++) {
+					const entry = bucket.entries[j];
+					const chainX = BUCKET_WIDTH + CHAIN_GAP + j * (CHAIN_NODE_SIZE + CHAIN_GAP);
+					const chainY = y + (BUCKET_HEIGHT - CHAIN_NODE_SIZE) / 2;
+					const isKeyHighlighted = entry.key === highlightedKey;
+
+					// Arrow from bucket/previous node
+					if (j === 0) {
+						const arrowG = new this.pixi.Graphics();
+						arrowG.moveTo(BUCKET_WIDTH, y + BUCKET_HEIGHT / 2);
+						arrowG.lineTo(chainX, y + BUCKET_HEIGHT / 2);
+						arrowG.stroke({ width: 1, color: strokeColor, alpha: 0.5 });
+						container.addChild(arrowG);
+					}
+
+					// Chain node
+					const nodeG = new this.pixi.Graphics();
+					nodeG.roundRect(chainX, chainY, CHAIN_NODE_SIZE, CHAIN_NODE_SIZE, 4);
+					const nodeColor = isKeyHighlighted ? highlightColor : fillColor;
+					nodeG.fill({ color: nodeColor });
+					nodeG.stroke({ width: 1, color: strokeColor });
+					container.addChild(nodeG);
+
+					// Key text
+					const keyStyle = new this.pixi.TextStyle({
+						fontSize: 8,
+						fontFamily: style.fontFamily,
+						fontWeight: '700',
+						fill: hexToPixiColor(style.textColor),
+					});
+					const keyText = new this.pixi.Text({
+						text: entry.key,
+						style: keyStyle,
+					});
+					keyText.anchor.set(0.5, 0.5);
+					keyText.position.set(chainX + CHAIN_NODE_SIZE / 2, chainY + CHAIN_NODE_SIZE / 2 - 4);
+					container.addChild(keyText);
+
+					// Value text (below key)
+					const valStyle = new this.pixi.TextStyle({
+						fontSize: 7,
+						fontFamily: style.fontFamily,
+						fontWeight: '400',
+						fill: hexToPixiColor('#9ca3af'),
+					});
+					const valText = new this.pixi.Text({
+						text: entry.value,
+						style: valStyle,
+					});
+					valText.anchor.set(0.5, 0.5);
+					valText.position.set(chainX + CHAIN_NODE_SIZE / 2, chainY + CHAIN_NODE_SIZE / 2 + 6);
+					container.addChild(valText);
+
+					// Chain link arrow
+					if (j < bucket.entries.length - 1) {
+						const linkG = new this.pixi.Graphics();
+						linkG.moveTo(chainX + CHAIN_NODE_SIZE, y + BUCKET_HEIGHT / 2);
+						linkG.lineTo(chainX + CHAIN_NODE_SIZE + CHAIN_GAP, y + BUCKET_HEIGHT / 2);
+						linkG.stroke({ width: 1, color: strokeColor, alpha: 0.5 });
+						container.addChild(linkG);
+					}
+
+					const entryPos: NodePosition = {
+						x: chainX + CHAIN_NODE_SIZE / 2,
+						y: chainY + CHAIN_NODE_SIZE / 2,
+					};
+					posMap.set(entry.key, entryPos);
+					entryMap.set(entry.key, container);
+				}
+			}
+		}
+
+		// Load factor
+		if (showLoadFactor) {
+			const totalEntries = buckets.reduce((sum, b) => sum + b.entries.length, 0);
+			const loadFactor = tableSize > 0 ? (totalEntries / tableSize).toFixed(2) : '0.00';
+			const lfStyle = new this.pixi.TextStyle({
+				fontSize: 9,
+				fontFamily: style.fontFamily,
+				fontWeight: '400',
+				fill: hexToPixiColor('#6b7280'),
+			});
+			const lfText = new this.pixi.Text({
+				text: `Load factor: ${loadFactor}`,
+				style: lfStyle,
+			});
+			lfText.anchor.set(0, 0);
+			lfText.position.set(0, tableSize * (BUCKET_HEIGHT + 4) + 8);
+			container.addChild(lfText);
+		}
+
+		this.bucketContainers[element.id] = bucketMap;
+		this.entryContainers[element.id] = entryMap;
+		this.entryPositions[element.id] = posMap;
+		return container;
+	}
+
+	/**
+	 * Get bucket containers for animation targeting.
+	 */
+	getBucketContainers(elementId: string): Map<number, PixiContainer> | undefined {
+		return this.bucketContainers[elementId];
+	}
+
+	/**
+	 * Get entry containers for animation targeting.
+	 */
+	getEntryContainers(elementId: string): Map<string, PixiContainer> | undefined {
+		return this.entryContainers[elementId];
+	}
+
+	/**
+	 * Get entry positions for animation targeting.
+	 */
+	getEntryPositions(elementId: string): Map<string, NodePosition> | undefined {
+		return this.entryPositions[elementId];
+	}
+}


### PR DESCRIPTION
## Summary
- Add `HashTableRenderer` with vertical bucket array, horizontal chain visualization, collision indicators, hash function label, and load factor display
- Add 6 GSAP animation presets: `hashCompute`, `hashInsert`, `hashInsertCollision`, `hashSearch`, `hashDelete`, `hashResize`
- 31 new tests (14 renderer + 17 presets), 1284 total suite passing

## Test plan
- [x] Empty table renders without errors
- [x] Bucket indices (0-3) render correctly
- [x] Entry keys (a, b, c) render in chain nodes
- [x] Hash function label displays `h(k) = key % 4`
- [x] Collision indicator (small circle) renders for bucket with collisions
- [x] Load factor text renders by default, hidden when disabled
- [x] Chain nodes render as rounded rectangles
- [x] Bucket/entry/position containers accessible for GSAP targeting
- [x] All 6 GSAP presets return valid timelines
- [x] Collision insert > simple insert duration
- [x] Longer chain = longer search duration
- [x] Resize scales with entry count
- [x] Quality gate: biome ✓ tsc ✓ vitest ✓

Closes #49

🤖 Generated with [Claude Code](https://claude.com/claude-code)