### PR TITLE
feat: implement Metrics Overlay with counter flash animations (#51)

### DIFF
--- a/src/lib/gsap/presets/metrics-presets.test.ts
+++ b/src/lib/gsap/presets/metrics-presets.test.ts
@@ -1,0 +1,89 @@
+/**
+ * Tests for Metrics Overlay GSAP animation presets.
+ */
+
+import gsap from 'gsap';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+	metricsBatchUpdate,
+	metricsComplexityReveal,
+	metricsCounterFlash,
+	metricsStepAdvance,
+} from './metrics-presets';
+
+interface MockNode {
+	alpha: number;
+	_fillColor: number;
+}
+
+function makeNode(): MockNode {
+	return { alpha: 0.8, _fillColor: 0xe5e7eb };
+}
+
+describe('Metrics Animation Presets', () => {
+	beforeEach(() => {
+		gsap.ticker.lagSmoothing(0);
+	});
+
+	describe('metricsCounterFlash', () => {
+		it('returns a GSAP timeline', () => {
+			const tl = metricsCounterFlash(makeNode(), 0xfbbf24);
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+		});
+
+		it('has positive duration', () => {
+			const tl = metricsCounterFlash(makeNode(), 0xfbbf24);
+			expect(tl.duration()).toBeGreaterThan(0);
+		});
+	});
+
+	describe('metricsStepAdvance', () => {
+		it('returns a GSAP timeline', () => {
+			const tl = metricsStepAdvance(makeNode(), 0xe5e7eb);
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+		});
+
+		it('has positive duration', () => {
+			const tl = metricsStepAdvance(makeNode(), 0xe5e7eb);
+			expect(tl.duration()).toBeGreaterThan(0);
+		});
+	});
+
+	describe('metricsBatchUpdate', () => {
+		it('returns a GSAP timeline', () => {
+			const tl = metricsBatchUpdate(
+				[makeNode(), makeNode(), makeNode()],
+				[0xfbbf24, 0xa78bfa, 0x22d3ee],
+			);
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+		});
+
+		it('has positive duration', () => {
+			const tl = metricsBatchUpdate([makeNode()], [0xfbbf24]);
+			expect(tl.duration()).toBeGreaterThan(0);
+		});
+
+		it('handles empty metrics', () => {
+			const tl = metricsBatchUpdate([], []);
+			expect(tl.duration()).toBe(0);
+		});
+	});
+
+	describe('metricsComplexityReveal', () => {
+		it('returns a GSAP timeline', () => {
+			const tl = metricsComplexityReveal(makeNode(), 0x4ade80);
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+		});
+
+		it('has positive duration', () => {
+			const tl = metricsComplexityReveal(makeNode(), 0x4ade80);
+			expect(tl.duration()).toBeGreaterThan(0);
+		});
+
+		it('has longer duration than counter flash', () => {
+			const flash = metricsCounterFlash(makeNode(), 0xfbbf24);
+			const reveal = metricsComplexityReveal(makeNode(), 0x4ade80);
+			expect(reveal.duration()).toBeGreaterThan(flash.duration());
+		});
+	});
+});

--- a/src/lib/gsap/presets/metrics-presets.ts
+++ b/src/lib/gsap/presets/metrics-presets.ts
@@ -1,0 +1,90 @@
+/**
+ * GSAP animation presets for Metrics Overlay.
+ *
+ * Provides animations for counter increments and flashes.
+ *
+ * Spec reference: Section 16.1 (Metrics Overlay)
+ */
+
+import gsap from 'gsap';
+
+interface AnimatableNode {
+	alpha: number;
+	_fillColor?: number;
+}
+
+/**
+ * Counter increment flash — briefly highlights a metric value
+ * when it changes. Used for comparisons, swaps, etc.
+ */
+export function metricsCounterFlash(
+	metricText: AnimatableNode,
+	flashColor: number,
+): gsap.core.Timeline {
+	const tl = gsap.timeline();
+
+	const originalColor = metricText._fillColor ?? 0xe5e7eb;
+
+	tl.to(metricText, { _fillColor: flashColor, alpha: 1, duration: 0.08 }, 0);
+	tl.to(metricText, { _fillColor: originalColor, alpha: 0.8, duration: 0.12 }, 0.1);
+
+	return tl;
+}
+
+/**
+ * Step progress — animates the step counter advancing.
+ * Pulses the step text on each increment.
+ */
+export function metricsStepAdvance(
+	stepText: AnimatableNode,
+	stepColor: number,
+): gsap.core.Timeline {
+	const tl = gsap.timeline();
+
+	tl.to(stepText, { _fillColor: stepColor, alpha: 1, duration: 0.06 }, 0);
+	tl.to(stepText, { alpha: 0.8, duration: 0.1 }, 0.08);
+
+	return tl;
+}
+
+/**
+ * Batch counter update — flashes multiple metrics simultaneously.
+ * Used when a single operation triggers multiple counter updates.
+ */
+export function metricsBatchUpdate(
+	metrics: AnimatableNode[],
+	flashColors: number[],
+): gsap.core.Timeline {
+	const tl = gsap.timeline();
+
+	for (let i = 0; i < metrics.length; i++) {
+		const metric = metrics[i];
+		const color = flashColors[i] ?? 0xfbbf24;
+		const originalColor = metric._fillColor ?? 0xe5e7eb;
+
+		tl.to(metric, { _fillColor: color, alpha: 1, duration: 0.08 }, 0);
+		tl.to(metric, { _fillColor: originalColor, alpha: 0.8, duration: 0.12 }, 0.1);
+	}
+
+	return tl;
+}
+
+/**
+ * Complexity reveal — fades in complexity notation with emphasis.
+ */
+export function metricsComplexityReveal(
+	complexityText: AnimatableNode,
+	revealColor: number,
+): gsap.core.Timeline {
+	const tl = gsap.timeline();
+
+	tl.fromTo(
+		complexityText,
+		{ alpha: 0, _fillColor: revealColor },
+		{ alpha: 1, duration: 0.3, ease: 'back.out' },
+		0,
+	);
+	tl.to(complexityText, { alpha: 0.8, duration: 0.15 }, 0.4);
+
+	return tl;
+}

--- a/src/lib/pixi/renderers/metrics-overlay-renderer.test.ts
+++ b/src/lib/pixi/renderers/metrics-overlay-renderer.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Tests for MetricsOverlayRenderer — algorithm performance display.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import type { JsonValue, SceneElement } from '@/types';
+import { MetricsOverlayRenderer } from './metrics-overlay-renderer';
+import { DEFAULT_ELEMENT_STYLE } from './shared';
+
+function createMockPixi() {
+	function MockContainer(this: Record<string, unknown>) {
+		const children: unknown[] = [];
+		this.addChild = vi.fn((...args: unknown[]) => children.push(...args));
+		this.removeChildren = vi.fn();
+		this.destroy = vi.fn();
+		this.position = { set: vi.fn(), x: 0, y: 0 };
+		this.alpha = 1;
+		this.angle = 0;
+		this.visible = true;
+		this.label = '';
+		this.cullable = false;
+		this.children = children;
+	}
+
+	function MockGraphics(this: Record<string, unknown>) {
+		this.clear = vi.fn().mockReturnThis();
+		this.rect = vi.fn().mockReturnThis();
+		this.roundRect = vi.fn().mockReturnThis();
+		this.circle = vi.fn().mockReturnThis();
+		this.fill = vi.fn().mockReturnThis();
+		this.stroke = vi.fn().mockReturnThis();
+		this.moveTo = vi.fn().mockReturnThis();
+		this.lineTo = vi.fn().mockReturnThis();
+		this.bezierCurveTo = vi.fn().mockReturnThis();
+		this.poly = vi.fn().mockReturnThis();
+		this.closePath = vi.fn().mockReturnThis();
+		this.destroy = vi.fn();
+	}
+
+	function MockText(this: Record<string, unknown>, opts: { text: string; style: unknown }) {
+		this.text = opts.text;
+		this.style = opts.style;
+		this.anchor = { set: vi.fn() };
+		this.position = { set: vi.fn() };
+		this.visible = true;
+		this.destroy = vi.fn();
+	}
+
+	function MockTextStyle(_opts: Record<string, unknown>) {
+		return { ..._opts };
+	}
+
+	return {
+		Container: vi.fn().mockImplementation(MockContainer),
+		Graphics: vi.fn().mockImplementation(MockGraphics),
+		Text: vi.fn().mockImplementation(MockText),
+		TextStyle: vi.fn().mockImplementation(MockTextStyle),
+	};
+}
+
+function makeElement(metadata: Record<string, JsonValue> = {}): SceneElement {
+	return {
+		id: 'metrics-1',
+		type: 'register',
+		position: { x: 0, y: 0 },
+		size: { width: 200, height: 200 },
+		rotation: 0,
+		opacity: 1,
+		visible: true,
+		locked: false,
+		style: DEFAULT_ELEMENT_STYLE,
+		metadata,
+	};
+}
+
+describe('MetricsOverlayRenderer', () => {
+	let renderer: MetricsOverlayRenderer;
+	let pixi: ReturnType<typeof createMockPixi>;
+
+	beforeEach(() => {
+		pixi = createMockPixi();
+		renderer = new MetricsOverlayRenderer(pixi as never);
+	});
+
+	describe('render', () => {
+		it('creates a container with defaults', () => {
+			const element = makeElement();
+			const container = renderer.render(element);
+			expect(container).toBeDefined();
+		});
+
+		it('renders title text', () => {
+			const element = makeElement();
+			renderer.render(element);
+
+			const textCalls = pixi.Text.mock.calls;
+			const title = textCalls.find((c: unknown[]) => (c[0] as { text: string }).text === 'Metrics');
+			expect(title).toBeDefined();
+		});
+
+		it('renders step counter', () => {
+			const element = makeElement({
+				currentStep: 5,
+				totalSteps: 20,
+			});
+			renderer.render(element);
+
+			const textCalls = pixi.Text.mock.calls;
+			const stepValue = textCalls.find(
+				(c: unknown[]) => (c[0] as { text: string }).text === '5 / 20',
+			);
+			expect(stepValue).toBeDefined();
+		});
+
+		it('renders comparison count', () => {
+			const element = makeElement({ comparisons: 42 });
+			renderer.render(element);
+
+			const textCalls = pixi.Text.mock.calls;
+			const compValue = textCalls.find((c: unknown[]) => (c[0] as { text: string }).text === '42');
+			expect(compValue).toBeDefined();
+		});
+
+		it('renders swap count', () => {
+			const element = makeElement({ swaps: 12 });
+			renderer.render(element);
+
+			const textCalls = pixi.Text.mock.calls;
+			const swapValue = textCalls.find((c: unknown[]) => (c[0] as { text: string }).text === '12');
+			expect(swapValue).toBeDefined();
+		});
+
+		it('renders memory access counts', () => {
+			const element = makeElement({ memoryReads: 100, memoryWrites: 50 });
+			renderer.render(element);
+
+			const textCalls = pixi.Text.mock.calls;
+			const memValue = textCalls.find(
+				(c: unknown[]) => (c[0] as { text: string }).text === 'R:100 W:50',
+			);
+			expect(memValue).toBeDefined();
+		});
+
+		it('hides memory when showMemory is false', () => {
+			const element = makeElement({
+				memoryReads: 100,
+				memoryWrites: 50,
+				showMemory: false,
+			});
+			renderer.render(element);
+
+			const textCalls = pixi.Text.mock.calls;
+			const memValue = textCalls.find(
+				(c: unknown[]) => (c[0] as { text: string }).text === 'R:100 W:50',
+			);
+			expect(memValue).toBeUndefined();
+		});
+
+		it('renders time complexity', () => {
+			const element = makeElement({ timeComplexity: 'O(n log n)' });
+			renderer.render(element);
+
+			const textCalls = pixi.Text.mock.calls;
+			const tcValue = textCalls.find(
+				(c: unknown[]) => (c[0] as { text: string }).text === 'O(n log n)',
+			);
+			expect(tcValue).toBeDefined();
+		});
+
+		it('renders space complexity', () => {
+			const element = makeElement({ spaceComplexity: 'O(n)' });
+			renderer.render(element);
+
+			const textCalls = pixi.Text.mock.calls;
+			const scValue = textCalls.find((c: unknown[]) => (c[0] as { text: string }).text === 'O(n)');
+			expect(scValue).toBeDefined();
+		});
+
+		it('hides complexity when showComplexity is false', () => {
+			const element = makeElement({
+				timeComplexity: 'O(n)',
+				spaceComplexity: 'O(1)',
+				showComplexity: false,
+			});
+			renderer.render(element);
+
+			const textCalls = pixi.Text.mock.calls;
+			const labels = textCalls.map((c: unknown[]) => (c[0] as { text: string }).text);
+			expect(labels).not.toContain('O(n)');
+			expect(labels).not.toContain('O(1)');
+		});
+
+		it('renders background panel with rounded rect', () => {
+			const element = makeElement();
+			renderer.render(element);
+
+			const graphicsResults = pixi.Graphics.mock.results;
+			const hasRoundRect = graphicsResults.some((r: { type: string; value?: unknown }) => {
+				const v = r.value as Record<string, { mock: { calls: unknown[][] } }> | undefined;
+				return (v?.roundRect?.mock?.calls?.length ?? 0) > 0;
+			});
+			expect(hasRoundRect).toBe(true);
+		});
+
+		it('renders metric labels', () => {
+			const element = makeElement();
+			renderer.render(element);
+
+			const textCalls = pixi.Text.mock.calls;
+			const labels = textCalls.map((c: unknown[]) => (c[0] as { text: string }).text);
+			expect(labels).toContain('Step');
+			expect(labels).toContain('Comparisons');
+			expect(labels).toContain('Swaps');
+		});
+
+		it('renders color dots for each metric', () => {
+			const element = makeElement();
+			renderer.render(element);
+
+			const graphicsResults = pixi.Graphics.mock.results;
+			const smallCircles = graphicsResults.filter((r: { type: string; value?: unknown }) => {
+				const v = r.value as Record<string, { mock: { calls: unknown[][] } }> | undefined;
+				const circleCalls = v?.circle?.mock?.calls ?? [];
+				return circleCalls.some((call: unknown[]) => (call[2] as number) === 3);
+			});
+			// At least 3 dots (steps, comparisons, swaps) + memory
+			expect(smallCircles.length).toBeGreaterThanOrEqual(3);
+		});
+	});
+
+	describe('getMetricTexts', () => {
+		it('returns text objects after render', () => {
+			const element = makeElement();
+			renderer.render(element);
+
+			const texts = renderer.getMetricTexts('metrics-1');
+			expect(texts).toBeDefined();
+			expect(texts?.size).toBeGreaterThanOrEqual(3);
+		});
+
+		it('returns undefined for unknown element', () => {
+			expect(renderer.getMetricTexts('nonexistent')).toBeUndefined();
+		});
+	});
+});

--- a/src/lib/pixi/renderers/metrics-overlay-renderer.ts
+++ b/src/lib/pixi/renderers/metrics-overlay-renderer.ts
@@ -1,0 +1,250 @@
+/**
+ * Renderer for Metrics Overlay — real-time algorithm performance display.
+ *
+ * Shows step counter, comparisons, swaps, memory accesses,
+ * time complexity, and space complexity in a semi-transparent
+ * overlay panel. Designed to be positioned in the top-right
+ * corner of the canvas viewport.
+ *
+ * Spec reference: Section 16.1 (Metrics Overlay)
+ */
+
+import type { SceneElement } from '@/types';
+import { hexToPixiColor } from './shared';
+
+// ── Pixi.js DI interfaces ──
+
+interface PixiContainer {
+	addChild(...children: unknown[]): void;
+	removeChildren(): void;
+	destroy(options?: { children: boolean }): void;
+	position: { set(x: number, y: number): void; x: number; y: number };
+	alpha: number;
+	angle: number;
+	visible: boolean;
+	label: string;
+	cullable: boolean;
+	children: unknown[];
+}
+
+interface PixiGraphics {
+	clear(): PixiGraphics;
+	rect(x: number, y: number, w: number, h: number): PixiGraphics;
+	roundRect(x: number, y: number, w: number, h: number, r: number): PixiGraphics;
+	circle(x: number, y: number, r: number): PixiGraphics;
+	fill(opts: { color: number; alpha?: number } | number): PixiGraphics;
+	stroke(opts: { width: number; color: number; alpha?: number }): PixiGraphics;
+	moveTo(x: number, y: number): PixiGraphics;
+	lineTo(x: number, y: number): PixiGraphics;
+	bezierCurveTo(
+		cp1x: number,
+		cp1y: number,
+		cp2x: number,
+		cp2y: number,
+		x: number,
+		y: number,
+	): PixiGraphics;
+	poly(points: number[]): PixiGraphics;
+	closePath(): PixiGraphics;
+	destroy(): void;
+}
+
+interface PixiText {
+	text: string;
+	style: Record<string, unknown>;
+	anchor: { set(x: number, y: number): void };
+	position: { set(x: number, y: number): void };
+	visible: boolean;
+	destroy(): void;
+}
+
+interface PixiModule {
+	Container: new () => PixiContainer;
+	Graphics: new () => PixiGraphics;
+	Text: new (opts: { text: string; style: unknown }) => PixiText;
+	TextStyle: new (opts: Record<string, unknown>) => Record<string, unknown>;
+}
+
+// ── Types ──
+
+export interface MetricsData {
+	currentStep: number;
+	totalSteps: number;
+	comparisons: number;
+	swaps: number;
+	memoryReads: number;
+	memoryWrites: number;
+	timeComplexity: string;
+	spaceComplexity: string;
+}
+
+// ── Colors ──
+
+const METRIC_COLORS: Record<string, string> = {
+	steps: '#e5e7eb',
+	comparisons: '#fbbf24',
+	swaps: '#a78bfa',
+	memory: '#22d3ee',
+	time: '#4ade80',
+	space: '#f97316',
+};
+
+// ── Constants ──
+
+const PANEL_WIDTH = 180;
+const ROW_HEIGHT = 18;
+const PADDING = 10;
+
+/**
+ * Renderer for Metrics Overlay.
+ */
+export class MetricsOverlayRenderer {
+	private pixi: PixiModule;
+	private metricTexts: Record<string, Map<string, PixiText>> = {};
+
+	constructor(pixi: PixiModule) {
+		this.pixi = pixi;
+	}
+
+	/**
+	 * Render a metrics overlay element.
+	 */
+	render(element: SceneElement): PixiContainer {
+		const container = new this.pixi.Container();
+		const { style, metadata } = element;
+
+		const metrics: MetricsData = {
+			currentStep: (metadata.currentStep as number) ?? 0,
+			totalSteps: (metadata.totalSteps as number) ?? 0,
+			comparisons: (metadata.comparisons as number) ?? 0,
+			swaps: (metadata.swaps as number) ?? 0,
+			memoryReads: (metadata.memoryReads as number) ?? 0,
+			memoryWrites: (metadata.memoryWrites as number) ?? 0,
+			timeComplexity: (metadata.timeComplexity as string) ?? '',
+			spaceComplexity: (metadata.spaceComplexity as string) ?? '',
+		};
+
+		const showMemory = (metadata.showMemory as boolean) ?? true;
+		const showComplexity = (metadata.showComplexity as boolean) ?? true;
+
+		const textMap = new Map<string, PixiText>();
+
+		// Build rows
+		const rows: Array<{ key: string; label: string; value: string; color: string }> = [
+			{
+				key: 'steps',
+				label: 'Step',
+				value: `${metrics.currentStep} / ${metrics.totalSteps}`,
+				color: METRIC_COLORS.steps,
+			},
+			{
+				key: 'comparisons',
+				label: 'Comparisons',
+				value: String(metrics.comparisons),
+				color: METRIC_COLORS.comparisons,
+			},
+			{
+				key: 'swaps',
+				label: 'Swaps',
+				value: String(metrics.swaps),
+				color: METRIC_COLORS.swaps,
+			},
+		];
+
+		if (showMemory) {
+			rows.push({
+				key: 'memory',
+				label: 'Memory',
+				value: `R:${metrics.memoryReads} W:${metrics.memoryWrites}`,
+				color: METRIC_COLORS.memory,
+			});
+		}
+
+		if (showComplexity && metrics.timeComplexity) {
+			rows.push({
+				key: 'time',
+				label: 'Time',
+				value: metrics.timeComplexity,
+				color: METRIC_COLORS.time,
+			});
+		}
+
+		if (showComplexity && metrics.spaceComplexity) {
+			rows.push({
+				key: 'space',
+				label: 'Space',
+				value: metrics.spaceComplexity,
+				color: METRIC_COLORS.space,
+			});
+		}
+
+		const panelHeight = PADDING * 2 + rows.length * ROW_HEIGHT + 16;
+
+		// Background panel
+		const bg = new this.pixi.Graphics();
+		bg.roundRect(0, 0, PANEL_WIDTH, panelHeight, 6);
+		bg.fill({ color: hexToPixiColor('#111827'), alpha: 0.85 });
+		bg.stroke({ width: 1, color: hexToPixiColor('#374151'), alpha: 0.6 });
+		container.addChild(bg);
+
+		// Title
+		const titleStyle = new this.pixi.TextStyle({
+			fontSize: 9,
+			fontFamily: style.fontFamily,
+			fontWeight: '700',
+			fill: hexToPixiColor('#e5e7eb'),
+		});
+		const titleText = new this.pixi.Text({ text: 'Metrics', style: titleStyle });
+		titleText.anchor.set(0, 0);
+		titleText.position.set(PADDING, PADDING);
+		container.addChild(titleText);
+
+		// Metric rows
+		for (let i = 0; i < rows.length; i++) {
+			const row = rows[i];
+			const y = PADDING + 16 + i * ROW_HEIGHT;
+
+			// Color dot
+			const dotG = new this.pixi.Graphics();
+			dotG.circle(PADDING + 4, y + 5, 3);
+			dotG.fill({ color: hexToPixiColor(row.color) });
+			container.addChild(dotG);
+
+			// Label
+			const labelStyle = new this.pixi.TextStyle({
+				fontSize: 8,
+				fontFamily: style.fontFamily,
+				fontWeight: '400',
+				fill: hexToPixiColor('#9ca3af'),
+			});
+			const labelText = new this.pixi.Text({ text: row.label, style: labelStyle });
+			labelText.anchor.set(0, 0);
+			labelText.position.set(PADDING + 12, y);
+			container.addChild(labelText);
+
+			// Value
+			const valueStyle = new this.pixi.TextStyle({
+				fontSize: 9,
+				fontFamily: style.fontFamily,
+				fontWeight: '700',
+				fill: hexToPixiColor(row.color),
+			});
+			const valueText = new this.pixi.Text({ text: row.value, style: valueStyle });
+			valueText.anchor.set(1, 0);
+			valueText.position.set(PANEL_WIDTH - PADDING, y);
+			container.addChild(valueText);
+
+			textMap.set(row.key, valueText as unknown as PixiText);
+		}
+
+		this.metricTexts[element.id] = textMap;
+		return container;
+	}
+
+	/**
+	 * Get metric text objects for animation (flash on increment).
+	 */
+	getMetricTexts(elementId: string): Map<string, PixiText> | undefined {
+		return this.metricTexts[elementId];
+	}
+}


### PR DESCRIPTION
## Summary
- Add `MetricsOverlayRenderer` with semi-transparent dark panel displaying algorithm performance metrics
- Metrics: step counter, comparisons (amber), swaps (violet), memory R/W (cyan), time complexity (green), space complexity (orange)
- Toggleable memory and complexity sections via `showMemory`/`showComplexity` metadata
- Add 4 GSAP animation presets: `metricsCounterFlash`, `metricsStepAdvance`, `metricsBatchUpdate`, `metricsComplexityReveal`
- 25 new tests (15 renderer + 10 presets), 1343 total suite passing

## Test plan
- [x] Default render creates container
- [x] Title "Metrics" renders
- [x] Step counter shows "5 / 20" format
- [x] Comparison/swap counts render correctly
- [x] Memory R:100 W:50 format renders
- [x] Memory hidden when showMemory=false
- [x] Time/space complexity renders O(n log n) / O(n)
- [x] Complexity hidden when showComplexity=false
- [x] Background panel uses roundRect
- [x] Color dots (radius=3) render per metric
- [x] All 4 GSAP presets return valid timelines
- [x] Complexity reveal > counter flash duration
- [x] Quality gate: biome ✓ tsc ✓ vitest ✓

Closes #51

🤖 Generated with [Claude Code](https://claude.com/claude-code)