### PR TITLE
feat: implement Algorithm Race Mode (#52)

### DIFF
--- a/src/lib/gsap/presets/race-presets.test.ts
+++ b/src/lib/gsap/presets/race-presets.test.ts
@@ -1,0 +1,126 @@
+/**
+ * Tests for Race Mode GSAP animation presets.
+ */
+
+import gsap from 'gsap';
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+	raceCountdownPulse,
+	raceCountdownSequence,
+	raceDividerFlash,
+	raceGoFlash,
+	raceLaneLabelSlide,
+	raceWinnerReveal,
+} from './race-presets';
+
+interface MockNode {
+	alpha: number;
+	scale: { x: number; y: number };
+	position: { x: number; y: number };
+	_fillColor: number;
+}
+
+function makeNode(): MockNode {
+	return {
+		alpha: 1,
+		scale: { x: 1, y: 1 },
+		position: { x: 0, y: 0 },
+		_fillColor: 0xffffff,
+	};
+}
+
+describe('Race Animation Presets', () => {
+	beforeEach(() => {
+		gsap.ticker.lagSmoothing(0);
+	});
+
+	describe('raceCountdownPulse', () => {
+		it('returns a GSAP timeline', () => {
+			const tl = raceCountdownPulse(makeNode());
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+		});
+
+		it('has positive duration', () => {
+			const tl = raceCountdownPulse(makeNode());
+			expect(tl.duration()).toBeGreaterThan(0);
+		});
+	});
+
+	describe('raceGoFlash', () => {
+		it('returns a GSAP timeline', () => {
+			const tl = raceGoFlash(makeNode(), makeNode());
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+		});
+
+		it('has positive duration', () => {
+			const tl = raceGoFlash(makeNode(), makeNode());
+			expect(tl.duration()).toBeGreaterThan(0);
+		});
+
+		it('has longer duration than countdown pulse', () => {
+			const pulse = raceCountdownPulse(makeNode());
+			const go = raceGoFlash(makeNode(), makeNode());
+			expect(go.duration()).toBeGreaterThanOrEqual(pulse.duration());
+		});
+	});
+
+	describe('raceCountdownSequence', () => {
+		it('returns a GSAP timeline', () => {
+			const tl = raceCountdownSequence(makeNode(), makeNode(), 3);
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+		});
+
+		it('has duration based on count', () => {
+			const tl3 = raceCountdownSequence(makeNode(), makeNode(), 3);
+			const tl5 = raceCountdownSequence(makeNode(), makeNode(), 5);
+			expect(tl5.duration()).toBeGreaterThan(tl3.duration());
+		});
+
+		it('has zero duration for count of 0', () => {
+			const tl = raceCountdownSequence(makeNode(), makeNode(), 0);
+			expect(tl.duration()).toBe(0);
+		});
+	});
+
+	describe('raceWinnerReveal', () => {
+		it('returns a GSAP timeline', () => {
+			const tl = raceWinnerReveal(makeNode(), makeNode(), makeNode());
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+		});
+
+		it('has positive duration', () => {
+			const tl = raceWinnerReveal(makeNode(), makeNode(), makeNode());
+			expect(tl.duration()).toBeGreaterThan(0);
+		});
+
+		it('has longer duration than go flash', () => {
+			const go = raceGoFlash(makeNode(), makeNode());
+			const winner = raceWinnerReveal(makeNode(), makeNode(), makeNode());
+			expect(winner.duration()).toBeGreaterThan(go.duration());
+		});
+	});
+
+	describe('raceLaneLabelSlide', () => {
+		it('returns a GSAP timeline', () => {
+			const tl = raceLaneLabelSlide(makeNode());
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+		});
+
+		it('has positive duration', () => {
+			const tl = raceLaneLabelSlide(makeNode());
+			expect(tl.duration()).toBeGreaterThan(0);
+		});
+	});
+
+	describe('raceDividerFlash', () => {
+		it('returns a GSAP timeline', () => {
+			const tl = raceDividerFlash(makeNode());
+			expect(tl).toBeInstanceOf(gsap.core.Timeline);
+		});
+
+		it('has positive duration', () => {
+			const tl = raceDividerFlash(makeNode());
+			expect(tl.duration()).toBeGreaterThan(0);
+		});
+	});
+});

--- a/src/lib/gsap/presets/race-presets.ts
+++ b/src/lib/gsap/presets/race-presets.ts
@@ -1,0 +1,162 @@
+/**
+ * GSAP animation presets for Algorithm Race Mode.
+ *
+ * Provides animations for countdown, GO! flash,
+ * winner reveal, lane labels, and divider effects.
+ *
+ * Spec reference: Section 16.2 (Algorithm Race Mode)
+ */
+
+import gsap from 'gsap';
+
+interface AnimatableNode {
+	alpha: number;
+	scale?: { x: number; y: number };
+	position?: { x: number; y: number };
+	_fillColor?: number;
+}
+
+/**
+ * Countdown number pulse — each number scales up and fades.
+ */
+export function raceCountdownPulse(countdownText: AnimatableNode): gsap.core.Timeline {
+	const tl = gsap.timeline();
+
+	tl.fromTo(countdownText, { alpha: 0 }, { alpha: 1, duration: 0.15, ease: 'power2.out' }, 0);
+
+	if (countdownText.scale) {
+		tl.fromTo(
+			countdownText.scale,
+			{ x: 1.5, y: 1.5 },
+			{ x: 1, y: 1, duration: 0.3, ease: 'back.out' },
+			0,
+		);
+	}
+
+	tl.to(countdownText, { alpha: 0, duration: 0.15 }, 0.6);
+
+	return tl;
+}
+
+/**
+ * GO! flash — green flash with scale emphasis.
+ */
+export function raceGoFlash(goText: AnimatableNode, backdrop: AnimatableNode): gsap.core.Timeline {
+	const tl = gsap.timeline();
+
+	// Flash the backdrop green briefly
+	tl.to(backdrop, { alpha: 0.8, duration: 0.1 }, 0);
+
+	// GO text scales up dramatically
+	tl.fromTo(goText, { alpha: 0 }, { alpha: 1, duration: 0.15, ease: 'power3.out' }, 0);
+
+	if (goText.scale) {
+		tl.fromTo(goText.scale, { x: 2, y: 2 }, { x: 1, y: 1, duration: 0.3, ease: 'back.out(2)' }, 0);
+	}
+
+	// Fade everything out
+	tl.to(goText, { alpha: 0, duration: 0.2 }, 0.5);
+	tl.to(backdrop, { alpha: 0, duration: 0.3 }, 0.5);
+
+	return tl;
+}
+
+/**
+ * Full countdown sequence — 3...2...1...GO!
+ * Each pulse is staggered by ~0.8s.
+ */
+export function raceCountdownSequence(
+	countdownText: AnimatableNode,
+	backdrop: AnimatableNode,
+	startCount: number,
+): gsap.core.Timeline {
+	const tl = gsap.timeline();
+
+	for (let i = startCount; i >= 1; i--) {
+		const offset = (startCount - i) * 0.8;
+		tl.add(raceCountdownPulse(countdownText), offset);
+	}
+
+	if (startCount > 0) {
+		// GO! at the end
+		const goOffset = startCount * 0.8;
+		tl.add(raceGoFlash(countdownText, backdrop), goOffset);
+	}
+
+	return tl;
+}
+
+/**
+ * Winner reveal — dramatic entrance with scale and glow.
+ */
+export function raceWinnerReveal(
+	backdrop: AnimatableNode,
+	titleText: AnimatableNode,
+	nameText: AnimatableNode,
+): gsap.core.Timeline {
+	const tl = gsap.timeline();
+
+	// Backdrop fades in
+	tl.fromTo(backdrop, { alpha: 0 }, { alpha: 0.7, duration: 0.3, ease: 'power2.out' }, 0);
+
+	// Title scales in with bounce
+	tl.fromTo(titleText, { alpha: 0 }, { alpha: 1, duration: 0.3, ease: 'back.out(2)' }, 0.2);
+	if (titleText.scale) {
+		tl.fromTo(
+			titleText.scale,
+			{ x: 0.3, y: 0.3 },
+			{ x: 1, y: 1, duration: 0.4, ease: 'back.out(2)' },
+			0.2,
+		);
+	}
+
+	// Name slides up
+	tl.fromTo(nameText, { alpha: 0 }, { alpha: 1, duration: 0.25 }, 0.5);
+	if (nameText.position) {
+		tl.fromTo(
+			nameText.position,
+			{ y: nameText.position.y + 20 },
+			{ y: nameText.position.y, duration: 0.3, ease: 'power2.out' },
+			0.5,
+		);
+	}
+
+	// Hold for a moment, then pulse title
+	tl.to(titleText, { alpha: 0.8, duration: 0.15 }, 1.0);
+	tl.to(titleText, { alpha: 1, duration: 0.15 }, 1.15);
+
+	return tl;
+}
+
+/**
+ * Lane label slide-in from top.
+ */
+export function raceLaneLabelSlide(label: AnimatableNode): gsap.core.Timeline {
+	const tl = gsap.timeline();
+
+	tl.fromTo(label, { alpha: 0 }, { alpha: 1, duration: 0.25, ease: 'power2.out' }, 0);
+
+	if (label.position) {
+		tl.fromTo(
+			label.position,
+			{ y: label.position.y - 20 },
+			{ y: label.position.y, duration: 0.3, ease: 'power2.out' },
+			0,
+		);
+	}
+
+	return tl;
+}
+
+/**
+ * Divider flash effect when race starts.
+ */
+export function raceDividerFlash(divider: AnimatableNode): gsap.core.Timeline {
+	const tl = gsap.timeline();
+
+	tl.fromTo(divider, { alpha: 0 }, { alpha: 1, duration: 0.1 }, 0);
+	tl.to(divider, { alpha: 0.4, duration: 0.15 }, 0.15);
+	tl.to(divider, { alpha: 0.8, duration: 0.1 }, 0.35);
+
+	return tl;
+}

--- a/src/lib/pixi/renderers/race-overlay-renderer.test.ts
+++ b/src/lib/pixi/renderers/race-overlay-renderer.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Tests for RaceOverlayRenderer — countdown & winner display.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { RaceOverlayRenderer } from './race-overlay-renderer';
+
+function createMockPixi() {
+	function MockContainer(this: Record<string, unknown>) {
+		const children: unknown[] = [];
+		this.addChild = vi.fn((...args: unknown[]) => children.push(...args));
+		this.removeChildren = vi.fn();
+		this.destroy = vi.fn();
+		this.position = { set: vi.fn(), x: 0, y: 0 };
+		this.alpha = 1;
+		this.angle = 0;
+		this.visible = true;
+		this.label = '';
+		this.cullable = false;
+		this.children = children;
+	}
+
+	function MockGraphics(this: Record<string, unknown>) {
+		this.clear = vi.fn().mockReturnThis();
+		this.rect = vi.fn().mockReturnThis();
+		this.roundRect = vi.fn().mockReturnThis();
+		this.circle = vi.fn().mockReturnThis();
+		this.fill = vi.fn().mockReturnThis();
+		this.stroke = vi.fn().mockReturnThis();
+		this.moveTo = vi.fn().mockReturnThis();
+		this.lineTo = vi.fn().mockReturnThis();
+		this.bezierCurveTo = vi.fn().mockReturnThis();
+		this.poly = vi.fn().mockReturnThis();
+		this.closePath = vi.fn().mockReturnThis();
+		this.destroy = vi.fn();
+	}
+
+	function MockText(this: Record<string, unknown>, opts: { text: string; style: unknown }) {
+		this.text = opts.text;
+		this.style = opts.style;
+		this.anchor = { set: vi.fn() };
+		this.position = { set: vi.fn() };
+		this.visible = true;
+		this.alpha = 1;
+		this.scale = { set: vi.fn(), x: 1, y: 1 };
+		this.destroy = vi.fn();
+	}
+
+	function MockTextStyle(_opts: Record<string, unknown>) {
+		return { ..._opts };
+	}
+
+	return {
+		Container: vi.fn().mockImplementation(MockContainer),
+		Graphics: vi.fn().mockImplementation(MockGraphics),
+		Text: vi.fn().mockImplementation(MockText),
+		TextStyle: vi.fn().mockImplementation(MockTextStyle),
+	};
+}
+
+describe('RaceOverlayRenderer', () => {
+	let renderer: RaceOverlayRenderer;
+	let pixi: ReturnType<typeof createMockPixi>;
+
+	beforeEach(() => {
+		pixi = createMockPixi();
+		renderer = new RaceOverlayRenderer(pixi as never);
+	});
+
+	describe('renderCountdown', () => {
+		it('creates a container', () => {
+			const container = renderer.renderCountdown(3, 800, 600);
+			expect(container).toBeDefined();
+		});
+
+		it('renders countdown number text', () => {
+			renderer.renderCountdown(3, 800, 600);
+
+			const textCalls = pixi.Text.mock.calls;
+			const countText = textCalls.find((c: unknown[]) => (c[0] as { text: string }).text === '3');
+			expect(countText).toBeDefined();
+		});
+
+		it('renders "GO!" for zero value', () => {
+			renderer.renderCountdown(0, 800, 600);
+
+			const textCalls = pixi.Text.mock.calls;
+			const goText = textCalls.find((c: unknown[]) => (c[0] as { text: string }).text === 'GO!');
+			expect(goText).toBeDefined();
+		});
+
+		it('renders backdrop', () => {
+			renderer.renderCountdown(3, 800, 600);
+
+			const graphicsResults = pixi.Graphics.mock.results;
+			const hasRect = graphicsResults.some((r: { type: string; value?: unknown }) => {
+				const v = r.value as Record<string, { mock: { calls: unknown[][] } }> | undefined;
+				return (v?.rect?.mock?.calls?.length ?? 0) > 0;
+			});
+			expect(hasRect).toBe(true);
+		});
+	});
+
+	describe('renderWinner', () => {
+		it('creates a container', () => {
+			const container = renderer.renderWinner('Quick Sort', 800, 600);
+			expect(container).toBeDefined();
+		});
+
+		it('renders winner title', () => {
+			renderer.renderWinner('Quick Sort', 800, 600);
+
+			const textCalls = pixi.Text.mock.calls;
+			const title = textCalls.find((c: unknown[]) => (c[0] as { text: string }).text === 'Winner!');
+			expect(title).toBeDefined();
+		});
+
+		it('renders algorithm name', () => {
+			renderer.renderWinner('Quick Sort', 800, 600);
+
+			const textCalls = pixi.Text.mock.calls;
+			const name = textCalls.find(
+				(c: unknown[]) => (c[0] as { text: string }).text === 'Quick Sort',
+			);
+			expect(name).toBeDefined();
+		});
+
+		it('renders trophy background circle', () => {
+			renderer.renderWinner('Merge Sort', 800, 600);
+
+			const graphicsResults = pixi.Graphics.mock.results;
+			const hasCircle = graphicsResults.some((r: { type: string; value?: unknown }) => {
+				const v = r.value as Record<string, { mock: { calls: unknown[][] } }> | undefined;
+				return (v?.circle?.mock?.calls?.length ?? 0) > 0;
+			});
+			expect(hasCircle).toBe(true);
+		});
+	});
+
+	describe('renderLaneLabel', () => {
+		it('creates a container with algorithm name', () => {
+			const container = renderer.renderLaneLabel('Bubble Sort', 400);
+			expect(container).toBeDefined();
+		});
+
+		it('renders the algorithm name text', () => {
+			renderer.renderLaneLabel('Heap Sort', 400);
+
+			const textCalls = pixi.Text.mock.calls;
+			const label = textCalls.find(
+				(c: unknown[]) => (c[0] as { text: string }).text === 'Heap Sort',
+			);
+			expect(label).toBeDefined();
+		});
+
+		it('renders background bar', () => {
+			renderer.renderLaneLabel('Selection Sort', 400);
+
+			const graphicsResults = pixi.Graphics.mock.results;
+			const hasRoundRect = graphicsResults.some((r: { type: string; value?: unknown }) => {
+				const v = r.value as Record<string, { mock: { calls: unknown[][] } }> | undefined;
+				return (v?.roundRect?.mock?.calls?.length ?? 0) > 0;
+			});
+			expect(hasRoundRect).toBe(true);
+		});
+	});
+
+	describe('renderDivider', () => {
+		it('creates a divider line', () => {
+			const container = renderer.renderDivider(600);
+			expect(container).toBeDefined();
+		});
+
+		it('draws a vertical line', () => {
+			renderer.renderDivider(600);
+
+			const graphicsResults = pixi.Graphics.mock.results;
+			const hasLine = graphicsResults.some((r: { type: string; value?: unknown }) => {
+				const v = r.value as Record<string, { mock: { calls: unknown[][] } }> | undefined;
+				return (
+					(v?.moveTo?.mock?.calls?.length ?? 0) > 0 && (v?.lineTo?.mock?.calls?.length ?? 0) > 0
+				);
+			});
+			expect(hasLine).toBe(true);
+		});
+	});
+
+	describe('getCountdownText', () => {
+		it('returns text object after render', () => {
+			renderer.renderCountdown(3, 800, 600);
+			const text = renderer.getCountdownText();
+			expect(text).toBeDefined();
+		});
+
+		it('returns undefined before render', () => {
+			expect(renderer.getCountdownText()).toBeUndefined();
+		});
+	});
+
+	describe('getWinnerTexts', () => {
+		it('returns text objects after render', () => {
+			renderer.renderWinner('Quick Sort', 800, 600);
+			const texts = renderer.getWinnerTexts();
+			expect(texts).toBeDefined();
+			expect(texts?.title).toBeDefined();
+			expect(texts?.name).toBeDefined();
+		});
+
+		it('returns undefined before render', () => {
+			expect(renderer.getWinnerTexts()).toBeUndefined();
+		});
+	});
+});

--- a/src/lib/pixi/renderers/race-overlay-renderer.ts
+++ b/src/lib/pixi/renderers/race-overlay-renderer.ts
@@ -1,0 +1,223 @@
+/**
+ * Renderer for Race Mode overlays — countdown, winner announcement,
+ * lane labels, and pane dividers.
+ *
+ * These are rendered on top of the split canvas panes during
+ * countdown and winner phases of Algorithm Race Mode.
+ *
+ * Spec reference: Section 16.2 (Algorithm Race Mode)
+ */
+
+import { hexToPixiColor } from './shared';
+
+// ── Pixi.js DI interfaces ──
+
+interface PixiContainer {
+	addChild(...children: unknown[]): void;
+	removeChildren(): void;
+	destroy(options?: { children: boolean }): void;
+	position: { set(x: number, y: number): void; x: number; y: number };
+	alpha: number;
+	angle: number;
+	visible: boolean;
+	label: string;
+	cullable: boolean;
+	children: unknown[];
+}
+
+interface PixiGraphics {
+	clear(): PixiGraphics;
+	rect(x: number, y: number, w: number, h: number): PixiGraphics;
+	roundRect(x: number, y: number, w: number, h: number, r: number): PixiGraphics;
+	circle(x: number, y: number, r: number): PixiGraphics;
+	fill(opts: { color: number; alpha?: number } | number): PixiGraphics;
+	stroke(opts: { width: number; color: number; alpha?: number }): PixiGraphics;
+	moveTo(x: number, y: number): PixiGraphics;
+	lineTo(x: number, y: number): PixiGraphics;
+	bezierCurveTo(
+		cp1x: number,
+		cp1y: number,
+		cp2x: number,
+		cp2y: number,
+		x: number,
+		y: number,
+	): PixiGraphics;
+	poly(points: number[]): PixiGraphics;
+	closePath(): PixiGraphics;
+	destroy(): void;
+}
+
+interface PixiText {
+	text: string;
+	style: Record<string, unknown>;
+	anchor: { set(x: number, y: number): void };
+	position: { set(x: number, y: number): void };
+	visible: boolean;
+	alpha: number;
+	scale: { set(x: number, y: number): void; x: number; y: number };
+	destroy(): void;
+}
+
+interface PixiModule {
+	Container: new () => PixiContainer;
+	Graphics: new () => PixiGraphics;
+	Text: new (opts: { text: string; style: unknown }) => PixiText;
+	TextStyle: new (opts: Record<string, unknown>) => Record<string, unknown>;
+}
+
+// ── Constants ──
+
+const COUNTDOWN_FONT_SIZE = 72;
+const WINNER_TITLE_FONT_SIZE = 32;
+const WINNER_NAME_FONT_SIZE = 24;
+const LABEL_FONT_SIZE = 12;
+const LABEL_HEIGHT = 28;
+const DIVIDER_COLOR = '#374151';
+
+/**
+ * Renderer for race mode overlays.
+ */
+export class RaceOverlayRenderer {
+	private pixi: PixiModule;
+	private countdownText: PixiText | undefined;
+	private winnerTitle: PixiText | undefined;
+	private winnerName: PixiText | undefined;
+
+	constructor(pixi: PixiModule) {
+		this.pixi = pixi;
+	}
+
+	/**
+	 * Render the countdown overlay (3, 2, 1, GO!).
+	 */
+	renderCountdown(value: number, width: number, height: number): PixiContainer {
+		const container = new this.pixi.Container();
+
+		// Semi-transparent backdrop
+		const bg = new this.pixi.Graphics();
+		bg.rect(0, 0, width, height);
+		bg.fill({ color: hexToPixiColor('#000000'), alpha: 0.6 });
+		container.addChild(bg);
+
+		// Countdown text
+		const displayText = value === 0 ? 'GO!' : String(value);
+		const style = new this.pixi.TextStyle({
+			fontSize: COUNTDOWN_FONT_SIZE,
+			fontFamily: 'JetBrains Mono, monospace',
+			fontWeight: '900',
+			fill: hexToPixiColor(value === 0 ? '#4ade80' : '#ffffff'),
+		});
+
+		const text = new this.pixi.Text({ text: displayText, style });
+		text.anchor.set(0.5, 0.5);
+		text.position.set(width / 2, height / 2);
+		container.addChild(text);
+
+		this.countdownText = text;
+		return container;
+	}
+
+	/**
+	 * Render the winner announcement overlay.
+	 */
+	renderWinner(algorithmName: string, width: number, height: number): PixiContainer {
+		const container = new this.pixi.Container();
+
+		// Semi-transparent backdrop
+		const bg = new this.pixi.Graphics();
+		bg.rect(0, 0, width, height);
+		bg.fill({ color: hexToPixiColor('#000000'), alpha: 0.7 });
+		container.addChild(bg);
+
+		// Trophy circle
+		const trophy = new this.pixi.Graphics();
+		trophy.circle(width / 2, height / 2 - 20, 40);
+		trophy.fill({ color: hexToPixiColor('#fbbf24'), alpha: 0.3 });
+		container.addChild(trophy);
+
+		// Winner title
+		const titleStyle = new this.pixi.TextStyle({
+			fontSize: WINNER_TITLE_FONT_SIZE,
+			fontFamily: 'JetBrains Mono, monospace',
+			fontWeight: '900',
+			fill: hexToPixiColor('#fbbf24'),
+		});
+		const title = new this.pixi.Text({ text: 'Winner!', style: titleStyle });
+		title.anchor.set(0.5, 0.5);
+		title.position.set(width / 2, height / 2 - 40);
+		container.addChild(title);
+
+		// Algorithm name
+		const nameStyle = new this.pixi.TextStyle({
+			fontSize: WINNER_NAME_FONT_SIZE,
+			fontFamily: 'JetBrains Mono, monospace',
+			fontWeight: '700',
+			fill: hexToPixiColor('#ffffff'),
+		});
+		const name = new this.pixi.Text({ text: algorithmName, style: nameStyle });
+		name.anchor.set(0.5, 0.5);
+		name.position.set(width / 2, height / 2 + 20);
+		container.addChild(name);
+
+		this.winnerTitle = title;
+		this.winnerName = name;
+		return container;
+	}
+
+	/**
+	 * Render a lane label bar at the top of a pane.
+	 */
+	renderLaneLabel(algorithmName: string, paneWidth: number): PixiContainer {
+		const container = new this.pixi.Container();
+
+		// Background bar
+		const bg = new this.pixi.Graphics();
+		bg.roundRect(0, 0, paneWidth, LABEL_HEIGHT, 4);
+		bg.fill({ color: hexToPixiColor('#1f2937'), alpha: 0.9 });
+		container.addChild(bg);
+
+		// Label text
+		const style = new this.pixi.TextStyle({
+			fontSize: LABEL_FONT_SIZE,
+			fontFamily: 'JetBrains Mono, monospace',
+			fontWeight: '700',
+			fill: hexToPixiColor('#e5e7eb'),
+		});
+		const text = new this.pixi.Text({ text: algorithmName, style });
+		text.anchor.set(0.5, 0.5);
+		text.position.set(paneWidth / 2, LABEL_HEIGHT / 2);
+		container.addChild(text);
+
+		return container;
+	}
+
+	/**
+	 * Render a vertical divider line between panes.
+	 */
+	renderDivider(height: number): PixiContainer {
+		const container = new this.pixi.Container();
+
+		const line = new this.pixi.Graphics();
+		line.moveTo(0, 0);
+		line.lineTo(0, height);
+		line.stroke({ width: 2, color: hexToPixiColor(DIVIDER_COLOR), alpha: 0.8 });
+		container.addChild(line);
+
+		return container;
+	}
+
+	/**
+	 * Get countdown text for animation.
+	 */
+	getCountdownText(): PixiText | undefined {
+		return this.countdownText;
+	}
+
+	/**
+	 * Get winner text objects for animation.
+	 */
+	getWinnerTexts(): { title: PixiText; name: PixiText } | undefined {
+		if (!this.winnerTitle || !this.winnerName) return undefined;
+		return { title: this.winnerTitle, name: this.winnerName };
+	}
+}

--- a/src/lib/race/race-orchestrator.test.ts
+++ b/src/lib/race/race-orchestrator.test.ts
@@ -1,0 +1,176 @@
+/**
+ * Tests for RaceOrchestrator — coordinates side-by-side algorithm races.
+ */
+
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { RaceOrchestrator } from './race-orchestrator';
+
+function makeEngine() {
+	return {
+		play: vi.fn(),
+		pause: vi.fn(),
+		setSpeed: vi.fn(),
+		destroy: vi.fn(),
+		isPlaying: false,
+		totalDuration: 10,
+		currentTime: 0,
+		onComplete: null as (() => void) | null,
+	};
+}
+
+describe('RaceOrchestrator', () => {
+	let orchestrator: RaceOrchestrator;
+
+	beforeEach(() => {
+		orchestrator = new RaceOrchestrator();
+	});
+
+	describe('registerLane', () => {
+		it('registers a lane with an engine', () => {
+			const engine = makeEngine();
+			orchestrator.registerLane('lane-1', engine);
+			expect(orchestrator.getLaneCount()).toBe(1);
+		});
+
+		it('registers multiple lanes', () => {
+			orchestrator.registerLane('lane-1', makeEngine());
+			orchestrator.registerLane('lane-2', makeEngine());
+			expect(orchestrator.getLaneCount()).toBe(2);
+		});
+	});
+
+	describe('unregisterLane', () => {
+		it('removes a lane', () => {
+			orchestrator.registerLane('lane-1', makeEngine());
+			orchestrator.unregisterLane('lane-1');
+			expect(orchestrator.getLaneCount()).toBe(0);
+		});
+	});
+
+	describe('startAll', () => {
+		it('calls play on all engines', () => {
+			const e1 = makeEngine();
+			const e2 = makeEngine();
+			orchestrator.registerLane('lane-1', e1);
+			orchestrator.registerLane('lane-2', e2);
+
+			orchestrator.startAll();
+
+			expect(e1.play).toHaveBeenCalledOnce();
+			expect(e2.play).toHaveBeenCalledOnce();
+		});
+	});
+
+	describe('pauseAll', () => {
+		it('calls pause on all engines', () => {
+			const e1 = makeEngine();
+			const e2 = makeEngine();
+			orchestrator.registerLane('lane-1', e1);
+			orchestrator.registerLane('lane-2', e2);
+
+			orchestrator.pauseAll();
+
+			expect(e1.pause).toHaveBeenCalledOnce();
+			expect(e2.pause).toHaveBeenCalledOnce();
+		});
+	});
+
+	describe('setLaneSpeed', () => {
+		it('sets speed on the specified lane engine', () => {
+			const e1 = makeEngine();
+			orchestrator.registerLane('lane-1', e1);
+
+			orchestrator.setLaneSpeed('lane-1', 2);
+
+			expect(e1.setSpeed).toHaveBeenCalledWith(2);
+		});
+
+		it('ignores unknown lane', () => {
+			// Should not throw
+			orchestrator.setLaneSpeed('nonexistent', 2);
+		});
+	});
+
+	describe('winner detection', () => {
+		it('calls onRaceComplete when first engine completes', () => {
+			const onComplete = vi.fn();
+			orchestrator.onRaceComplete = onComplete;
+
+			const e1 = makeEngine();
+			const e2 = makeEngine();
+			orchestrator.registerLane('lane-1', e1);
+			orchestrator.registerLane('lane-2', e2);
+
+			orchestrator.startAll();
+
+			// Simulate engine 2 completing first
+			e2.onComplete?.();
+
+			expect(onComplete).toHaveBeenCalledWith('lane-2');
+		});
+
+		it('does not call onRaceComplete for second finisher', () => {
+			const onComplete = vi.fn();
+			orchestrator.onRaceComplete = onComplete;
+
+			const e1 = makeEngine();
+			const e2 = makeEngine();
+			orchestrator.registerLane('lane-1', e1);
+			orchestrator.registerLane('lane-2', e2);
+
+			orchestrator.startAll();
+
+			e2.onComplete?.();
+			e1.onComplete?.();
+
+			expect(onComplete).toHaveBeenCalledOnce();
+		});
+
+		it('pauses remaining engines after winner', () => {
+			const e1 = makeEngine();
+			const e2 = makeEngine();
+			orchestrator.registerLane('lane-1', e1);
+			orchestrator.registerLane('lane-2', e2);
+
+			orchestrator.startAll();
+			e1.onComplete?.();
+
+			expect(e2.pause).toHaveBeenCalled();
+		});
+	});
+
+	describe('resetAll', () => {
+		it('clears winner state', () => {
+			const e1 = makeEngine();
+			const e2 = makeEngine();
+			orchestrator.registerLane('lane-1', e1);
+			orchestrator.registerLane('lane-2', e2);
+
+			orchestrator.startAll();
+			e1.onComplete?.();
+			orchestrator.resetAll();
+
+			// After reset, should be able to detect winner again
+			const onComplete = vi.fn();
+			orchestrator.onRaceComplete = onComplete;
+			orchestrator.startAll();
+			e2.onComplete?.();
+			expect(onComplete).toHaveBeenCalledWith('lane-2');
+		});
+	});
+
+	describe('destroy', () => {
+		it('destroys all engines', () => {
+			const e1 = makeEngine();
+			const e2 = makeEngine();
+			orchestrator.registerLane('lane-1', e1);
+			orchestrator.registerLane('lane-2', e2);
+
+			orchestrator.destroy();
+
+			expect(e1.destroy).toHaveBeenCalledOnce();
+			expect(e2.destroy).toHaveBeenCalledOnce();
+			expect(orchestrator.getLaneCount()).toBe(0);
+		});
+	});
+});

--- a/src/lib/race/race-orchestrator.ts
+++ b/src/lib/race/race-orchestrator.ts
@@ -1,0 +1,89 @@
+/**
+ * RaceOrchestrator — coordinates side-by-side algorithm races.
+ *
+ * Manages multiple AnimationEngine instances, one per lane.
+ * Provides synchronized start, per-lane speed control,
+ * and automatic winner detection when the first engine completes.
+ *
+ * Spec reference: Section 16.2 (Algorithm Race Mode)
+ */
+
+export interface RaceEngine {
+	play(): void;
+	pause(): void;
+	setSpeed(multiplier: number): void;
+	destroy(): void;
+	isPlaying: boolean;
+	totalDuration: number;
+	currentTime: number;
+	onComplete: (() => void) | null;
+}
+
+export class RaceOrchestrator {
+	private lanes: Map<string, RaceEngine> = new Map();
+	private winnerFound = false;
+
+	/** Called when the first engine completes (winner detected). */
+	onRaceComplete: ((winnerId: string) => void) | null = null;
+
+	getLaneCount(): number {
+		return this.lanes.size;
+	}
+
+	registerLane(laneId: string, engine: RaceEngine): void {
+		this.lanes.set(laneId, engine);
+	}
+
+	unregisterLane(laneId: string): void {
+		this.lanes.delete(laneId);
+	}
+
+	startAll(): void {
+		this.winnerFound = false;
+
+		for (const [laneId, engine] of this.lanes) {
+			engine.onComplete = () => this.handleLaneComplete(laneId);
+			engine.play();
+		}
+	}
+
+	pauseAll(): void {
+		for (const engine of this.lanes.values()) {
+			engine.pause();
+		}
+	}
+
+	setLaneSpeed(laneId: string, speed: number): void {
+		const engine = this.lanes.get(laneId);
+		if (engine) {
+			engine.setSpeed(speed);
+		}
+	}
+
+	resetAll(): void {
+		this.winnerFound = false;
+	}
+
+	destroy(): void {
+		for (const engine of this.lanes.values()) {
+			engine.destroy();
+		}
+		this.lanes.clear();
+		this.onRaceComplete = null;
+	}
+
+	private handleLaneComplete(laneId: string): void {
+		if (this.winnerFound) return;
+
+		this.winnerFound = true;
+
+		// Pause all other engines
+		for (const [id, engine] of this.lanes) {
+			if (id !== laneId) {
+				engine.pause();
+			}
+		}
+
+		this.onRaceComplete?.(laneId);
+	}
+}

--- a/src/lib/stores/race-store.test.ts
+++ b/src/lib/stores/race-store.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Tests for Race Mode Zustand store.
+ */
+
+import { act } from 'react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useRaceStore } from './race-store';
+
+function resetStore() {
+	act(() => {
+		useRaceStore.getState().reset();
+	});
+}
+
+describe('RaceStore', () => {
+	beforeEach(() => {
+		resetStore();
+	});
+
+	describe('initial state', () => {
+		it('starts in idle status', () => {
+			expect(useRaceStore.getState().status).toBe('idle');
+		});
+
+		it('has two empty lanes', () => {
+			const { lanes, laneIds } = useRaceStore.getState();
+			expect(laneIds).toHaveLength(0);
+			expect(Object.keys(lanes)).toHaveLength(0);
+		});
+
+		it('has no winner', () => {
+			expect(useRaceStore.getState().winnerId).toBeNull();
+		});
+
+		it('has default countdown value', () => {
+			expect(useRaceStore.getState().countdownValue).toBe(3);
+		});
+
+		it('has empty shared input', () => {
+			expect(useRaceStore.getState().sharedInput).toEqual([]);
+		});
+	});
+
+	describe('addLane', () => {
+		it('adds a lane with algorithm name', () => {
+			act(() => {
+				useRaceStore.getState().addLane('lane-1', 'Bubble Sort');
+			});
+
+			const { lanes, laneIds } = useRaceStore.getState();
+			expect(laneIds).toEqual(['lane-1']);
+			expect(lanes['lane-1']).toEqual({
+				id: 'lane-1',
+				algorithmName: 'Bubble Sort',
+				speed: 1,
+				status: 'idle',
+				metrics: {
+					currentStep: 0,
+					totalSteps: 0,
+					comparisons: 0,
+					swaps: 0,
+				},
+			});
+		});
+
+		it('adds multiple lanes', () => {
+			act(() => {
+				useRaceStore.getState().addLane('lane-1', 'Bubble Sort');
+				useRaceStore.getState().addLane('lane-2', 'Quick Sort');
+			});
+
+			expect(useRaceStore.getState().laneIds).toHaveLength(2);
+		});
+	});
+
+	describe('removeLane', () => {
+		it('removes a lane', () => {
+			act(() => {
+				useRaceStore.getState().addLane('lane-1', 'Bubble Sort');
+				useRaceStore.getState().removeLane('lane-1');
+			});
+
+			expect(useRaceStore.getState().laneIds).toHaveLength(0);
+			expect(useRaceStore.getState().lanes['lane-1']).toBeUndefined();
+		});
+	});
+
+	describe('setLaneSpeed', () => {
+		it('sets speed for a lane', () => {
+			act(() => {
+				useRaceStore.getState().addLane('lane-1', 'Bubble Sort');
+				useRaceStore.getState().setLaneSpeed('lane-1', 2);
+			});
+
+			expect(useRaceStore.getState().lanes['lane-1']?.speed).toBe(2);
+		});
+
+		it('ignores unknown lane', () => {
+			act(() => {
+				useRaceStore.getState().setLaneSpeed('nonexistent', 2);
+			});
+			// No error thrown
+		});
+	});
+
+	describe('setLaneStatus', () => {
+		it('sets status for a lane', () => {
+			act(() => {
+				useRaceStore.getState().addLane('lane-1', 'Bubble Sort');
+				useRaceStore.getState().setLaneStatus('lane-1', 'running');
+			});
+
+			expect(useRaceStore.getState().lanes['lane-1']?.status).toBe('running');
+		});
+	});
+
+	describe('updateLaneMetrics', () => {
+		it('updates metrics for a lane', () => {
+			act(() => {
+				useRaceStore.getState().addLane('lane-1', 'Bubble Sort');
+				useRaceStore.getState().updateLaneMetrics('lane-1', {
+					currentStep: 5,
+					comparisons: 10,
+				});
+			});
+
+			const metrics = useRaceStore.getState().lanes['lane-1']?.metrics;
+			expect(metrics?.currentStep).toBe(5);
+			expect(metrics?.comparisons).toBe(10);
+			expect(metrics?.swaps).toBe(0); // untouched
+		});
+	});
+
+	describe('race lifecycle', () => {
+		it('transitions through countdown -> racing -> finished', () => {
+			act(() => {
+				useRaceStore.getState().addLane('lane-1', 'Bubble Sort');
+				useRaceStore.getState().addLane('lane-2', 'Quick Sort');
+			});
+
+			act(() => {
+				useRaceStore.getState().startCountdown();
+			});
+			expect(useRaceStore.getState().status).toBe('countdown');
+
+			act(() => {
+				useRaceStore.getState().startRace();
+			});
+			expect(useRaceStore.getState().status).toBe('racing');
+
+			act(() => {
+				useRaceStore.getState().finishRace('lane-2');
+			});
+			expect(useRaceStore.getState().status).toBe('finished');
+			expect(useRaceStore.getState().winnerId).toBe('lane-2');
+		});
+	});
+
+	describe('setCountdownValue', () => {
+		it('decrements countdown', () => {
+			act(() => {
+				useRaceStore.getState().setCountdownValue(2);
+			});
+			expect(useRaceStore.getState().countdownValue).toBe(2);
+		});
+	});
+
+	describe('setSharedInput', () => {
+		it('sets shared input array', () => {
+			act(() => {
+				useRaceStore.getState().setSharedInput([5, 3, 8, 1, 9]);
+			});
+			expect(useRaceStore.getState().sharedInput).toEqual([5, 3, 8, 1, 9]);
+		});
+	});
+
+	describe('reset', () => {
+		it('resets to initial state', () => {
+			act(() => {
+				useRaceStore.getState().addLane('lane-1', 'Bubble Sort');
+				useRaceStore.getState().startCountdown();
+				useRaceStore.getState().setSharedInput([1, 2, 3]);
+				useRaceStore.getState().reset();
+			});
+
+			const state = useRaceStore.getState();
+			expect(state.status).toBe('idle');
+			expect(state.laneIds).toHaveLength(0);
+			expect(state.winnerId).toBeNull();
+			expect(state.sharedInput).toEqual([]);
+		});
+	});
+});

--- a/src/lib/stores/race-store.ts
+++ b/src/lib/stores/race-store.ts
@@ -1,0 +1,149 @@
+/**
+ * Zustand store for Algorithm Race Mode state.
+ *
+ * Manages race lanes, countdown, winner detection,
+ * per-lane speed controls, and shared input data.
+ *
+ * Spec reference: Section 16.2 (Algorithm Race Mode)
+ */
+
+import { create } from 'zustand';
+import { devtools } from 'zustand/middleware';
+import { immer } from 'zustand/middleware/immer';
+
+// ── Types ──
+
+export type RaceStatus = 'idle' | 'countdown' | 'racing' | 'finished';
+export type LaneStatus = 'idle' | 'running' | 'completed';
+
+export interface LaneMetrics {
+	currentStep: number;
+	totalSteps: number;
+	comparisons: number;
+	swaps: number;
+}
+
+export interface RaceLane {
+	id: string;
+	algorithmName: string;
+	speed: number;
+	status: LaneStatus;
+	metrics: LaneMetrics;
+}
+
+// ── State & Actions ──
+
+export interface RaceState {
+	status: RaceStatus;
+	lanes: Record<string, RaceLane>;
+	laneIds: string[];
+	winnerId: string | null;
+	countdownValue: number;
+	sharedInput: number[];
+}
+
+export interface RaceActions {
+	addLane: (id: string, algorithmName: string) => void;
+	removeLane: (id: string) => void;
+	setLaneSpeed: (id: string, speed: number) => void;
+	setLaneStatus: (id: string, status: LaneStatus) => void;
+	updateLaneMetrics: (id: string, updates: Partial<LaneMetrics>) => void;
+	startCountdown: () => void;
+	startRace: () => void;
+	finishRace: (winnerId: string) => void;
+	setCountdownValue: (value: number) => void;
+	setSharedInput: (input: number[]) => void;
+	reset: () => void;
+}
+
+export type RaceStore = RaceState & RaceActions;
+
+const initialState: RaceState = {
+	status: 'idle',
+	lanes: {},
+	laneIds: [],
+	winnerId: null,
+	countdownValue: 3,
+	sharedInput: [],
+};
+
+export const useRaceStore = create<RaceStore>()(
+	devtools(
+		immer((set) => ({
+			...initialState,
+
+			addLane: (id, algorithmName) =>
+				set((state) => {
+					state.lanes[id] = {
+						id,
+						algorithmName,
+						speed: 1,
+						status: 'idle',
+						metrics: {
+							currentStep: 0,
+							totalSteps: 0,
+							comparisons: 0,
+							swaps: 0,
+						},
+					};
+					state.laneIds.push(id);
+				}),
+
+			removeLane: (id) =>
+				set((state) => {
+					delete state.lanes[id];
+					state.laneIds = state.laneIds.filter((lid) => lid !== id);
+				}),
+
+			setLaneSpeed: (id, speed) =>
+				set((state) => {
+					const lane = state.lanes[id];
+					if (lane) lane.speed = speed;
+				}),
+
+			setLaneStatus: (id, status) =>
+				set((state) => {
+					const lane = state.lanes[id];
+					if (lane) lane.status = status;
+				}),
+
+			updateLaneMetrics: (id, updates) =>
+				set((state) => {
+					const lane = state.lanes[id];
+					if (lane) {
+						Object.assign(lane.metrics, updates);
+					}
+				}),
+
+			startCountdown: () =>
+				set((state) => {
+					state.status = 'countdown';
+					state.countdownValue = 3;
+				}),
+
+			startRace: () =>
+				set((state) => {
+					state.status = 'racing';
+				}),
+
+			finishRace: (winnerId) =>
+				set((state) => {
+					state.status = 'finished';
+					state.winnerId = winnerId;
+				}),
+
+			setCountdownValue: (value) =>
+				set((state) => {
+					state.countdownValue = value;
+				}),
+
+			setSharedInput: (input) =>
+				set((state) => {
+					state.sharedInput = input;
+				}),
+
+			reset: () => set(initialState),
+		})),
+		{ name: 'RaceStore', enabled: process.env.NODE_ENV === 'development' },
+	),
+);


### PR DESCRIPTION
## Summary
- **RaceOrchestrator** (`src/lib/race/`) — Coordinates multiple independent AnimationEngine instances for side-by-side algorithm comparison. Features synchronized start, per-lane speed control via `timeScale()`, and automatic winner detection via `onComplete` callbacks (first-to-finish wins, remaining engines pause).
- **RaceOverlayRenderer** (`src/lib/pixi/renderers/`) — Pixi.js renderer for race UI overlays: countdown (3, 2, 1, GO!), winner announcement with trophy circle, lane labels, and pane dividers.
- **race-store** (`src/lib/stores/`) — Zustand store managing race lifecycle (idle → countdown → racing → finished), per-lane metrics, shared input data, and winner tracking. Uses `Record<>` pattern per project conventions.
- **race-presets** (`src/lib/gsap/presets/`) — 6 GSAP animation presets: `raceCountdownPulse`, `raceGoFlash`, `raceCountdownSequence`, `raceWinnerReveal`, `raceLaneLabelSlide`, `raceDividerFlash`.

## Test plan
- [x] RaceStore: 16 tests (lifecycle, lane management, metrics, reset)
- [x] RaceOrchestrator: 12 tests (register/unregister, startAll/pauseAll, speed control, winner detection, reset, destroy)
- [x] RaceOverlayRenderer: 17 tests (countdown, GO!, winner, lane labels, divider, text accessors)
- [x] Race GSAP presets: 15 tests (all 6 presets, duration relationships, count scaling)
- [x] Full suite: 1403 tests passing across 97 files
- [x] Quality gate: Biome clean (1 pre-existing error), tsc clean

Closes #52

🤖 Generated with [Claude Code](https://claude.com/claude-code)