### PR TITLE
feat: set up Supabase auth (OAuth + magic link) (#56)

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,6 +17,8 @@
 	"dependencies": {
 		"@monaco-editor/react": "^4.7.0",
 		"@sentry/nextjs": "latest",
+		"@supabase/ssr": "^0.8.0",
+		"@supabase/supabase-js": "^2.95.3",
 		"@vercel/analytics": "latest",
 		"@vercel/speed-insights": "latest",
 		"acorn": "^8.15.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,12 @@ importers:
       '@sentry/nextjs':
         specifier: latest
         version: 10.38.0(@opentelemetry/context-async-hooks@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/core@2.5.0(@opentelemetry/api@1.9.0))(@opentelemetry/sdk-trace-base@2.5.0(@opentelemetry/api@1.9.0))(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)(webpack@5.105.1)
+      '@supabase/ssr':
+        specifier: ^0.8.0
+        version: 0.8.0(@supabase/supabase-js@2.95.3)
+      '@supabase/supabase-js':
+        specifier: ^2.95.3
+        version: 2.95.3
       '@vercel/analytics':
         specifier: latest
         version: 1.6.1(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)
@@ -2158,6 +2164,35 @@ packages:
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
 
+  '@supabase/auth-js@2.95.3':
+    resolution: {integrity: sha512-vD2YoS8E2iKIX0F7EwXTmqhUpaNsmbU6X2R0/NdFcs02oEfnHyNP/3M716f3wVJ2E5XHGiTFXki6lRckhJ0Thg==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/functions-js@2.95.3':
+    resolution: {integrity: sha512-uTuOAKzs9R/IovW1krO0ZbUHSJnsnyJElTXIRhjJTqymIVGcHzkAYnBCJqd7468Fs/Foz1BQ7Dv6DCl05lr7ig==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/postgrest-js@2.95.3':
+    resolution: {integrity: sha512-LTrRBqU1gOovxRm1vRXPItSMPBmEFqrfTqdPTRtzOILV4jPSueFz6pES5hpb4LRlkFwCPRmv3nQJ5N625V2Xrg==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/realtime-js@2.95.3':
+    resolution: {integrity: sha512-D7EAtfU3w6BEUxDACjowWNJo/ZRo7sDIuhuOGKHIm9FHieGeoJV5R6GKTLtga/5l/6fDr2u+WcW/m8I9SYmaIw==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/ssr@0.8.0':
+    resolution: {integrity: sha512-/PKk8kNFSs8QvvJ2vOww1mF5/c5W8y42duYtXvkOSe+yZKRgTTZywYG2l41pjhNomqESZCpZtXuWmYjFRMV+dw==}
+    peerDependencies:
+      '@supabase/supabase-js': ^2.76.1
+
+  '@supabase/storage-js@2.95.3':
+    resolution: {integrity: sha512-4GxkJiXI3HHWjxpC3sDx1BVrV87O0hfX+wvJdqGv67KeCu+g44SPnII8y0LL/Wr677jB7tpjAxKdtVWf+xhc9A==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/supabase-js@2.95.3':
+    resolution: {integrity: sha512-Fukw1cUTQ6xdLiHDJhKKPu6svEPaCEDvThqCne3OaQyZvuq2qjhJAd91kJu3PXLG18aooCgYBaB6qQz35hhABg==}
+    engines: {node: '>=20.0.0'}
+
   '@swc/helpers@0.5.15':
     resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
 
@@ -2336,6 +2371,9 @@ packages:
   '@types/pg@8.15.6':
     resolution: {integrity: sha512-NoaMtzhxOrubeL/7UZuNTrejB4MPAJ0RpxZqXQf2qXuVlTPuG6Y8p4u9dKRaue4yjmC7ZhzVO2/Yyyn25znrPQ==}
 
+  '@types/phoenix@1.6.7':
+    resolution: {integrity: sha512-oN9ive//QSBkf19rfDv45M7eZPi0eEXylht2OLEXicu5b4KoQ1OzXIw+xDSGWxSxe1JmepRR/ZH283vsu518/Q==}
+
   '@types/react-dom@19.2.3':
     resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
     peerDependencies:
@@ -2355,6 +2393,9 @@ packages:
 
   '@types/validate-npm-package-name@4.0.2':
     resolution: {integrity: sha512-lrpDziQipxCEeK5kWxvljWYhUvOiB2A9izZd9B2AFarYAkqZshb4lPbRs7zKEic6eGtH8V/2qJW+dPp9OtF6bw==}
+
+  '@types/ws@8.18.1':
+    resolution: {integrity: sha512-ThVF6DCVhA8kUGy+aazFQ4kXQ7E1Ty7A3ypFOe0IcJV8O/M511G99AW24irKrW56Wt44yG9+ij8FaqoBGkuBXg==}
 
   '@vercel/analytics@1.6.1':
     resolution: {integrity: sha512-oH9He/bEM+6oKlv3chWuOOcp8Y6fo6/PSro8hEkgCW3pu9/OiCXiUpRUogDh3Fs3LH2sosDrx8CxeOLBEE+afg==}
@@ -3251,6 +3292,10 @@ packages:
   human-signals@8.0.1:
     resolution: {integrity: sha512-eKCa6bwnJhvxj14kZk5NCPc6Hb6BdsU9DZcOnmQKSnO1VKrfV0zCvtttPZUsBvjmNDn8rpcJfpwSYnHBjc95MQ==}
     engines: {node: '>=18.18.0'}
+
+  iceberg-js@0.8.1:
+    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
+    engines: {node: '>=20.0.0'}
 
   iconv-lite@0.7.2:
     resolution: {integrity: sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw==}
@@ -4625,6 +4670,18 @@ packages:
 
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
+
+  ws@8.19.0:
+    resolution: {integrity: sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
 
   wsl-utils@0.3.1:
     resolution: {integrity: sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==}
@@ -6699,6 +6756,49 @@ snapshots:
 
   '@standard-schema/spec@1.1.0': {}
 
+  '@supabase/auth-js@2.95.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/functions-js@2.95.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/postgrest-js@2.95.3':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/realtime-js@2.95.3':
+    dependencies:
+      '@types/phoenix': 1.6.7
+      '@types/ws': 8.18.1
+      tslib: 2.8.1
+      ws: 8.19.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
+  '@supabase/ssr@0.8.0(@supabase/supabase-js@2.95.3)':
+    dependencies:
+      '@supabase/supabase-js': 2.95.3
+      cookie: 1.1.1
+
+  '@supabase/storage-js@2.95.3':
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+
+  '@supabase/supabase-js@2.95.3':
+    dependencies:
+      '@supabase/auth-js': 2.95.3
+      '@supabase/functions-js': 2.95.3
+      '@supabase/postgrest-js': 2.95.3
+      '@supabase/realtime-js': 2.95.3
+      '@supabase/storage-js': 2.95.3
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
+
   '@swc/helpers@0.5.15':
     dependencies:
       tslib: 2.8.1
@@ -6880,6 +6980,8 @@ snapshots:
       pg-protocol: 1.11.0
       pg-types: 2.2.0
 
+  '@types/phoenix@1.6.7': {}
+
   '@types/react-dom@19.2.3(@types/react@19.2.14)':
     dependencies:
       '@types/react': 19.2.14
@@ -6898,6 +7000,10 @@ snapshots:
     optional: true
 
   '@types/validate-npm-package-name@4.0.2': {}
+
+  '@types/ws@8.18.1':
+    dependencies:
+      '@types/node': 22.19.11
 
   '@vercel/analytics@1.6.1(next@16.1.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.0)(@playwright/test@1.58.2)(babel-plugin-react-compiler@1.0.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3))(react@19.2.3)':
     optionalDependencies:
@@ -7764,6 +7870,8 @@ snapshots:
   human-signals@2.1.0: {}
 
   human-signals@8.0.1: {}
+
+  iceberg-js@0.8.1: {}
 
   iconv-lite@0.7.2:
     dependencies:
@@ -9139,6 +9247,8 @@ snapshots:
       strip-ansi: 7.1.2
 
   wrappy@1.0.2: {}
+
+  ws@8.19.0: {}
 
   wsl-utils@0.3.1:
     dependencies:

--- a/src/app/(auth)/callback/page.tsx
+++ b/src/app/(auth)/callback/page.tsx
@@ -5,6 +5,13 @@ export const metadata: Metadata = {
 	description: 'Completing authentication...',
 };
 
+/**
+ * Fallback callback page — shown briefly during OAuth redirect.
+ *
+ * The actual OAuth code exchange happens in the Route Handler at
+ * /auth/callback/route.ts. This page at /callback is shown only
+ * if a user navigates directly to /callback.
+ */
 export default function CallbackPage() {
 	return (
 		<div className="space-y-4 text-center">

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { LoginForm } from '@/components/auth/login-form';
 
 export const metadata: Metadata = {
 	title: 'Sign In — AlgoMotion',
@@ -6,15 +7,5 @@ export const metadata: Metadata = {
 };
 
 export default function LoginPage() {
-	return (
-		<div className="space-y-4 text-center">
-			<div className="flex justify-center">
-				<div className="flex h-12 w-12 items-center justify-center rounded-xl bg-primary">
-					<span className="text-xl font-bold text-primary-foreground">A</span>
-				</div>
-			</div>
-			<h1 className="text-2xl font-semibold">Sign in to AlgoMotion</h1>
-			<p className="text-sm text-muted-foreground">Authentication coming soon (Supabase Auth)</p>
-		</div>
-	);
+	return <LoginForm />;
 }

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from 'next';
+import { SignupForm } from '@/components/auth/signup-form';
 
 export const metadata: Metadata = {
 	title: 'Sign Up — AlgoMotion',
@@ -6,15 +7,5 @@ export const metadata: Metadata = {
 };
 
 export default function SignupPage() {
-	return (
-		<div className="space-y-4 text-center">
-			<div className="flex justify-center">
-				<div className="flex h-12 w-12 items-center justify-center rounded-xl bg-primary">
-					<span className="text-xl font-bold text-primary-foreground">A</span>
-				</div>
-			</div>
-			<h1 className="text-2xl font-semibold">Create your account</h1>
-			<p className="text-sm text-muted-foreground">Registration coming soon (Supabase Auth)</p>
-		</div>
-	);
+	return <SignupForm />;
 }

--- a/src/app/auth/callback/route.test.ts
+++ b/src/app/auth/callback/route.test.ts
@@ -1,0 +1,108 @@
+/**
+ * Tests for auth callback route handler.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+const mockExchangeCodeForSession = vi.fn();
+
+vi.mock('@supabase/ssr', () => ({
+	createServerClient: vi.fn(() => ({
+		auth: {
+			exchangeCodeForSession: mockExchangeCodeForSession,
+		},
+	})),
+}));
+
+vi.mock('next/headers', () => ({
+	cookies: vi.fn(() => ({
+		getAll: vi.fn(() => []),
+		set: vi.fn(),
+	})),
+}));
+
+vi.mock('next/server', () => ({
+	NextResponse: {
+		redirect: vi.fn((url: string) => ({ redirectUrl: url })),
+	},
+}));
+
+describe('auth callback route', () => {
+	it('exports a GET handler', async () => {
+		const mod = await import('./route');
+		expect(mod.GET).toBeDefined();
+		expect(typeof mod.GET).toBe('function');
+	});
+
+	it('exchanges code for session on success', async () => {
+		mockExchangeCodeForSession.mockResolvedValueOnce({ error: null });
+
+		const { GET } = await import('./route');
+		const searchParams = new URLSearchParams({ code: 'test-code' });
+
+		const request = {
+			nextUrl: {
+				searchParams,
+				origin: 'http://localhost:3000',
+			},
+		} as never;
+
+		await GET(request);
+
+		expect(mockExchangeCodeForSession).toHaveBeenCalledWith('test-code');
+	});
+
+	it('redirects to login on missing code', async () => {
+		const { GET } = await import('./route');
+		const { NextResponse } = await import('next/server');
+
+		const request = {
+			nextUrl: {
+				searchParams: new URLSearchParams(),
+				origin: 'http://localhost:3000',
+			},
+		} as never;
+
+		await GET(request);
+
+		expect(NextResponse.redirect).toHaveBeenCalledWith(
+			'http://localhost:3000/login?error=auth_callback_failed',
+		);
+	});
+
+	it('redirects to dashboard by default after successful exchange', async () => {
+		mockExchangeCodeForSession.mockResolvedValueOnce({ error: null });
+
+		const { GET } = await import('./route');
+		const { NextResponse } = await import('next/server');
+
+		const request = {
+			nextUrl: {
+				searchParams: new URLSearchParams({ code: 'valid-code' }),
+				origin: 'http://localhost:3000',
+			},
+		} as never;
+
+		await GET(request);
+
+		expect(NextResponse.redirect).toHaveBeenCalledWith('http://localhost:3000/dashboard');
+	});
+
+	it('redirects to custom next path after successful exchange', async () => {
+		mockExchangeCodeForSession.mockResolvedValueOnce({ error: null });
+
+		const { GET } = await import('./route');
+		const { NextResponse } = await import('next/server');
+
+		const request = {
+			nextUrl: {
+				searchParams: new URLSearchParams({ code: 'valid-code', next: '/editor/123' }),
+				origin: 'http://localhost:3000',
+			},
+		} as never;
+
+		await GET(request);
+
+		expect(NextResponse.redirect).toHaveBeenCalledWith('http://localhost:3000/editor/123');
+	});
+});

--- a/src/app/auth/callback/route.ts
+++ b/src/app/auth/callback/route.ts
@@ -1,0 +1,47 @@
+/**
+ * Auth callback route handler — exchanges OAuth code for session.
+ *
+ * Supabase redirects here after OAuth or magic link auth.
+ * The code is exchanged server-side for a session, then the
+ * user is redirected to their intended destination.
+ *
+ * Spec reference: Section 4 (Auth)
+ */
+
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+import { type NextRequest, NextResponse } from 'next/server';
+
+export async function GET(request: NextRequest) {
+	const { searchParams, origin } = request.nextUrl;
+	const code = searchParams.get('code');
+	const next = searchParams.get('next') ?? '/dashboard';
+
+	if (code) {
+		const cookieStore = await cookies();
+		const supabase = createServerClient(
+			process.env.NEXT_PUBLIC_SUPABASE_URL!,
+			process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+			{
+				cookies: {
+					getAll() {
+						return cookieStore.getAll();
+					},
+					setAll(cookiesToSet) {
+						for (const { name, value, options } of cookiesToSet) {
+							cookieStore.set(name, value, options);
+						}
+					},
+				},
+			},
+		);
+
+		const { error } = await supabase.auth.exchangeCodeForSession(code);
+		if (!error) {
+			return NextResponse.redirect(`${origin}${next}`);
+		}
+	}
+
+	// If no code or exchange failed, redirect to login with error
+	return NextResponse.redirect(`${origin}/login?error=auth_callback_failed`);
+}

--- a/src/components/auth/login-form.test.tsx
+++ b/src/components/auth/login-form.test.tsx
@@ -1,0 +1,74 @@
+/**
+ * Tests for login form component.
+ */
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/hooks/use-auth', () => ({
+	useAuth: vi.fn(() => ({
+		user: null,
+		loading: false,
+		signInWithOAuth: vi.fn(),
+		signInWithMagicLink: vi.fn(),
+		signInWithPassword: vi.fn(),
+		signUp: vi.fn(),
+		signOut: vi.fn(),
+	})),
+}));
+
+vi.mock('@/lib/supabase/client', () => ({
+	createClient: vi.fn(() => ({
+		auth: {
+			getSession: vi.fn(() => Promise.resolve({ data: { session: null }, error: null })),
+			onAuthStateChange: vi.fn(() => ({
+				data: { subscription: { unsubscribe: vi.fn() } },
+			})),
+		},
+	})),
+}));
+
+afterEach(cleanup);
+
+describe('LoginForm', () => {
+	it('exports LoginForm component', async () => {
+		const mod = await import('./login-form');
+		expect(mod.LoginForm).toBeDefined();
+	});
+
+	it('renders without crashing', async () => {
+		const { LoginForm } = await import('./login-form');
+		const { container } = render(<LoginForm />);
+		expect(container.querySelector('form')).not.toBeNull();
+	});
+
+	it('renders email input', async () => {
+		const { LoginForm } = await import('./login-form');
+		render(<LoginForm />);
+		expect(screen.getByPlaceholderText('you@example.com')).toBeDefined();
+	});
+
+	it('renders password input', async () => {
+		const { LoginForm } = await import('./login-form');
+		render(<LoginForm />);
+		expect(screen.getByPlaceholderText('Your password')).toBeDefined();
+	});
+
+	it('renders sign-in submit button', async () => {
+		const { LoginForm } = await import('./login-form');
+		render(<LoginForm />);
+		expect(screen.getByRole('button', { name: 'Sign in' })).toBeDefined();
+	});
+
+	it('renders magic link button', async () => {
+		const { LoginForm } = await import('./login-form');
+		render(<LoginForm />);
+		expect(screen.getByRole('button', { name: /magic link/i })).toBeDefined();
+	});
+
+	it('renders link to signup page', async () => {
+		const { LoginForm } = await import('./login-form');
+		render(<LoginForm />);
+		expect(screen.getByRole('link', { name: 'Sign up' })).toBeDefined();
+	});
+});

--- a/src/components/auth/login-form.tsx
+++ b/src/components/auth/login-form.tsx
@@ -1,0 +1,132 @@
+/**
+ * Login form — email/password + magic link + OAuth.
+ *
+ * Client Component that provides all authentication methods
+ * supported by the app. Renders in the centered auth layout.
+ *
+ * Spec reference: Section 4 (Auth)
+ */
+
+'use client';
+
+import Link from 'next/link';
+import { type FormEvent, useState } from 'react';
+import { OAuthButtons } from '@/components/auth/oauth-buttons';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Separator } from '@/components/ui/separator';
+import { useAuth } from '@/hooks/use-auth';
+
+export function LoginForm() {
+	const { signInWithPassword, signInWithMagicLink } = useAuth();
+	const [email, setEmail] = useState('');
+	const [password, setPassword] = useState('');
+	const [error, setError] = useState<string | null>(null);
+	const [message, setMessage] = useState<string | null>(null);
+	const [loading, setLoading] = useState(false);
+
+	async function handlePasswordLogin(e: FormEvent) {
+		e.preventDefault();
+		setError(null);
+		setMessage(null);
+		setLoading(true);
+
+		const result = await signInWithPassword(email, password);
+		if (result.error) {
+			setError(result.error.message);
+		}
+		setLoading(false);
+	}
+
+	async function handleMagicLink() {
+		if (!email) {
+			setError('Please enter your email address');
+			return;
+		}
+		setError(null);
+		setMessage(null);
+		setLoading(true);
+
+		const result = await signInWithMagicLink(email);
+		if (result.error) {
+			setError(result.error.message);
+		} else {
+			setMessage('Check your email for the magic link!');
+		}
+		setLoading(false);
+	}
+
+	return (
+		<div className="space-y-6">
+			<div className="space-y-2 text-center">
+				<div className="flex justify-center">
+					<div className="flex h-12 w-12 items-center justify-center rounded-xl bg-primary">
+						<span className="text-xl font-bold text-primary-foreground">A</span>
+					</div>
+				</div>
+				<h1 className="text-2xl font-semibold">Sign in to AlgoMotion</h1>
+				<p className="text-sm text-muted-foreground">Choose your preferred sign-in method</p>
+			</div>
+
+			<OAuthButtons />
+
+			<div className="relative">
+				<Separator />
+				<span className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-background px-2 text-xs text-muted-foreground">
+					or continue with email
+				</span>
+			</div>
+
+			<form onSubmit={handlePasswordLogin} className="space-y-4">
+				<div className="space-y-2">
+					<Label htmlFor="email">Email</Label>
+					<Input
+						id="email"
+						type="email"
+						placeholder="you@example.com"
+						value={email}
+						onChange={(e) => setEmail(e.target.value)}
+						required
+					/>
+				</div>
+
+				<div className="space-y-2">
+					<Label htmlFor="password">Password</Label>
+					<Input
+						id="password"
+						type="password"
+						placeholder="Your password"
+						value={password}
+						onChange={(e) => setPassword(e.target.value)}
+					/>
+				</div>
+
+				{error && <p className="text-sm text-destructive">{error}</p>}
+				{message && <p className="text-sm text-green-600 dark:text-green-400">{message}</p>}
+
+				<div className="space-y-2">
+					<Button type="submit" className="w-full" disabled={loading}>
+						{loading ? 'Signing in...' : 'Sign in'}
+					</Button>
+					<Button
+						type="button"
+						variant="ghost"
+						className="w-full"
+						onClick={handleMagicLink}
+						disabled={loading}
+					>
+						Send magic link instead
+					</Button>
+				</div>
+			</form>
+
+			<p className="text-center text-sm text-muted-foreground">
+				Don&apos;t have an account?{' '}
+				<Link href="/signup" className="text-primary hover:underline">
+					Sign up
+				</Link>
+			</p>
+		</div>
+	);
+}

--- a/src/components/auth/oauth-buttons.test.tsx
+++ b/src/components/auth/oauth-buttons.test.tsx
@@ -1,0 +1,35 @@
+/**
+ * Tests for OAuth buttons component.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/hooks/use-auth', () => ({
+	useAuth: vi.fn(() => ({
+		user: null,
+		loading: false,
+		signInWithOAuth: vi.fn(),
+		signInWithMagicLink: vi.fn(),
+		signInWithPassword: vi.fn(),
+		signUp: vi.fn(),
+		signOut: vi.fn(),
+	})),
+}));
+
+vi.mock('@/lib/supabase/client', () => ({
+	createClient: vi.fn(() => ({
+		auth: {
+			getSession: vi.fn(() => Promise.resolve({ data: { session: null }, error: null })),
+			onAuthStateChange: vi.fn(() => ({
+				data: { subscription: { unsubscribe: vi.fn() } },
+			})),
+		},
+	})),
+}));
+
+describe('OAuthButtons', () => {
+	it('exports OAuthButtons component', async () => {
+		const mod = await import('./oauth-buttons');
+		expect(mod.OAuthButtons).toBeDefined();
+	});
+});

--- a/src/components/auth/oauth-buttons.tsx
+++ b/src/components/auth/oauth-buttons.tsx
@@ -1,0 +1,36 @@
+/**
+ * OAuth sign-in buttons — Google and GitHub providers.
+ *
+ * Reusable across login and signup pages.
+ * Uses the useAuth hook for Supabase OAuth flow.
+ *
+ * Spec reference: Section 4 (Auth)
+ */
+
+'use client';
+
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { useAuth } from '@/hooks/use-auth';
+
+export function OAuthButtons() {
+	const { signInWithOAuth } = useAuth();
+	const [loading, setLoading] = useState<string | null>(null);
+
+	async function handleOAuth(provider: 'google' | 'github') {
+		setLoading(provider);
+		await signInWithOAuth(provider);
+		setLoading(null);
+	}
+
+	return (
+		<div className="grid grid-cols-2 gap-3">
+			<Button variant="outline" onClick={() => handleOAuth('github')} disabled={loading !== null}>
+				{loading === 'github' ? 'Connecting...' : 'GitHub'}
+			</Button>
+			<Button variant="outline" onClick={() => handleOAuth('google')} disabled={loading !== null}>
+				{loading === 'google' ? 'Connecting...' : 'Google'}
+			</Button>
+		</div>
+	);
+}

--- a/src/components/auth/signup-form.test.tsx
+++ b/src/components/auth/signup-form.test.tsx
@@ -1,0 +1,68 @@
+/**
+ * Tests for signup form component.
+ */
+
+import { cleanup, render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/hooks/use-auth', () => ({
+	useAuth: vi.fn(() => ({
+		user: null,
+		loading: false,
+		signInWithOAuth: vi.fn(),
+		signInWithMagicLink: vi.fn(),
+		signInWithPassword: vi.fn(),
+		signUp: vi.fn(),
+		signOut: vi.fn(),
+	})),
+}));
+
+vi.mock('@/lib/supabase/client', () => ({
+	createClient: vi.fn(() => ({
+		auth: {
+			getSession: vi.fn(() => Promise.resolve({ data: { session: null }, error: null })),
+			onAuthStateChange: vi.fn(() => ({
+				data: { subscription: { unsubscribe: vi.fn() } },
+			})),
+		},
+	})),
+}));
+
+afterEach(cleanup);
+
+describe('SignupForm', () => {
+	it('exports SignupForm component', async () => {
+		const mod = await import('./signup-form');
+		expect(mod.SignupForm).toBeDefined();
+	});
+
+	it('renders without crashing', async () => {
+		const { SignupForm } = await import('./signup-form');
+		const { container } = render(<SignupForm />);
+		expect(container.querySelector('form')).not.toBeNull();
+	});
+
+	it('renders email input', async () => {
+		const { SignupForm } = await import('./signup-form');
+		render(<SignupForm />);
+		expect(screen.getByPlaceholderText('you@example.com')).toBeDefined();
+	});
+
+	it('renders password input', async () => {
+		const { SignupForm } = await import('./signup-form');
+		render(<SignupForm />);
+		expect(screen.getByPlaceholderText('Create a password')).toBeDefined();
+	});
+
+	it('renders create account button', async () => {
+		const { SignupForm } = await import('./signup-form');
+		render(<SignupForm />);
+		expect(screen.getByRole('button', { name: 'Create account' })).toBeDefined();
+	});
+
+	it('renders link to login page', async () => {
+		const { SignupForm } = await import('./signup-form');
+		render(<SignupForm />);
+		expect(screen.getByRole('link', { name: 'Sign in' })).toBeDefined();
+	});
+});

--- a/src/components/auth/signup-form.tsx
+++ b/src/components/auth/signup-form.tsx
@@ -1,0 +1,108 @@
+/**
+ * Signup form — email/password + OAuth registration.
+ *
+ * Client Component that provides account creation.
+ * Renders in the centered auth layout.
+ *
+ * Spec reference: Section 4 (Auth)
+ */
+
+'use client';
+
+import Link from 'next/link';
+import { type FormEvent, useState } from 'react';
+import { OAuthButtons } from '@/components/auth/oauth-buttons';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Separator } from '@/components/ui/separator';
+import { useAuth } from '@/hooks/use-auth';
+
+export function SignupForm() {
+	const { signUp } = useAuth();
+	const [email, setEmail] = useState('');
+	const [password, setPassword] = useState('');
+	const [error, setError] = useState<string | null>(null);
+	const [message, setMessage] = useState<string | null>(null);
+	const [loading, setLoading] = useState(false);
+
+	async function handleSignup(e: FormEvent) {
+		e.preventDefault();
+		setError(null);
+		setMessage(null);
+		setLoading(true);
+
+		const result = await signUp(email, password);
+		if (result.error) {
+			setError(result.error.message);
+		} else {
+			setMessage('Check your email to confirm your account!');
+		}
+		setLoading(false);
+	}
+
+	return (
+		<div className="space-y-6">
+			<div className="space-y-2 text-center">
+				<div className="flex justify-center">
+					<div className="flex h-12 w-12 items-center justify-center rounded-xl bg-primary">
+						<span className="text-xl font-bold text-primary-foreground">A</span>
+					</div>
+				</div>
+				<h1 className="text-2xl font-semibold">Create your account</h1>
+				<p className="text-sm text-muted-foreground">Get started with AlgoMotion</p>
+			</div>
+
+			<OAuthButtons />
+
+			<div className="relative">
+				<Separator />
+				<span className="absolute top-1/2 left-1/2 -translate-x-1/2 -translate-y-1/2 bg-background px-2 text-xs text-muted-foreground">
+					or sign up with email
+				</span>
+			</div>
+
+			<form onSubmit={handleSignup} className="space-y-4">
+				<div className="space-y-2">
+					<Label htmlFor="email">Email</Label>
+					<Input
+						id="email"
+						type="email"
+						placeholder="you@example.com"
+						value={email}
+						onChange={(e) => setEmail(e.target.value)}
+						required
+					/>
+				</div>
+
+				<div className="space-y-2">
+					<Label htmlFor="password">Password</Label>
+					<Input
+						id="password"
+						type="password"
+						placeholder="Create a password"
+						value={password}
+						onChange={(e) => setPassword(e.target.value)}
+						required
+						minLength={6}
+					/>
+					<p className="text-xs text-muted-foreground">Must be at least 6 characters</p>
+				</div>
+
+				{error && <p className="text-sm text-destructive">{error}</p>}
+				{message && <p className="text-sm text-green-600 dark:text-green-400">{message}</p>}
+
+				<Button type="submit" className="w-full" disabled={loading}>
+					{loading ? 'Creating account...' : 'Create account'}
+				</Button>
+			</form>
+
+			<p className="text-center text-sm text-muted-foreground">
+				Already have an account?{' '}
+				<Link href="/login" className="text-primary hover:underline">
+					Sign in
+				</Link>
+			</p>
+		</div>
+	);
+}

--- a/src/hooks/use-auth.test.ts
+++ b/src/hooks/use-auth.test.ts
@@ -1,0 +1,67 @@
+/**
+ * Tests for useAuth hook — client-side auth state.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/supabase/client', () => ({
+	createClient: vi.fn(() => ({
+		auth: {
+			getSession: vi.fn(() => Promise.resolve({ data: { session: null }, error: null })),
+			onAuthStateChange: vi.fn(() => ({
+				data: { subscription: { unsubscribe: vi.fn() } },
+			})),
+		},
+	})),
+}));
+
+describe('useAuth', () => {
+	it('exports useAuth hook', async () => {
+		const mod = await import('./use-auth');
+		expect(mod.useAuth).toBeDefined();
+	});
+
+	it('returns initial state with no user', async () => {
+		const { useAuth } = await import('./use-auth');
+		const { result } = renderHook(() => useAuth());
+
+		expect(result.current.user).toBeNull();
+		expect(result.current.loading).toBe(true);
+	});
+
+	it('provides signOut function', async () => {
+		const { useAuth } = await import('./use-auth');
+		const { result } = renderHook(() => useAuth());
+
+		expect(typeof result.current.signOut).toBe('function');
+	});
+
+	it('provides signInWithOAuth function', async () => {
+		const { useAuth } = await import('./use-auth');
+		const { result } = renderHook(() => useAuth());
+
+		expect(typeof result.current.signInWithOAuth).toBe('function');
+	});
+
+	it('provides signInWithMagicLink function', async () => {
+		const { useAuth } = await import('./use-auth');
+		const { result } = renderHook(() => useAuth());
+
+		expect(typeof result.current.signInWithMagicLink).toBe('function');
+	});
+
+	it('provides signInWithPassword function', async () => {
+		const { useAuth } = await import('./use-auth');
+		const { result } = renderHook(() => useAuth());
+
+		expect(typeof result.current.signInWithPassword).toBe('function');
+	});
+
+	it('provides signUp function', async () => {
+		const { useAuth } = await import('./use-auth');
+		const { result } = renderHook(() => useAuth());
+
+		expect(typeof result.current.signUp).toBe('function');
+	});
+});

--- a/src/hooks/use-auth.ts
+++ b/src/hooks/use-auth.ts
@@ -1,0 +1,105 @@
+/**
+ * Client-side auth hook — provides user state and auth methods.
+ *
+ * Listens to Supabase auth state changes and provides
+ * sign-in, sign-up, and sign-out functions for Client Components.
+ *
+ * Spec reference: Section 4 (Auth)
+ */
+
+'use client';
+
+import type { Provider, User } from '@supabase/supabase-js';
+import { useCallback, useEffect, useState } from 'react';
+import { createClient } from '@/lib/supabase/client';
+
+export interface AuthState {
+	user: User | null;
+	loading: boolean;
+	signInWithOAuth: (provider: Provider) => Promise<void>;
+	signInWithMagicLink: (email: string) => Promise<{ error: Error | null }>;
+	signInWithPassword: (email: string, password: string) => Promise<{ error: Error | null }>;
+	signUp: (email: string, password: string) => Promise<{ error: Error | null }>;
+	signOut: () => Promise<void>;
+}
+
+export function useAuth(): AuthState {
+	const [user, setUser] = useState<User | null>(null);
+	const [loading, setLoading] = useState(true);
+
+	useEffect(() => {
+		const supabase = createClient();
+
+		// Get initial session
+		supabase.auth.getSession().then(({ data: { session } }) => {
+			setUser(session?.user ?? null);
+			setLoading(false);
+		});
+
+		// Listen for auth changes
+		const {
+			data: { subscription },
+		} = supabase.auth.onAuthStateChange((_event, session) => {
+			setUser(session?.user ?? null);
+			setLoading(false);
+		});
+
+		return () => {
+			subscription.unsubscribe();
+		};
+	}, []);
+
+	const signInWithOAuth = useCallback(async (provider: Provider) => {
+		const supabase = createClient();
+		await supabase.auth.signInWithOAuth({
+			provider,
+			options: {
+				redirectTo: `${window.location.origin}/auth/callback`,
+			},
+		});
+	}, []);
+
+	const signInWithMagicLink = useCallback(async (email: string) => {
+		const supabase = createClient();
+		const { error } = await supabase.auth.signInWithOtp({
+			email,
+			options: {
+				emailRedirectTo: `${window.location.origin}/auth/callback`,
+			},
+		});
+		return { error: error ? new Error(error.message) : null };
+	}, []);
+
+	const signInWithPassword = useCallback(async (email: string, password: string) => {
+		const supabase = createClient();
+		const { error } = await supabase.auth.signInWithPassword({ email, password });
+		return { error: error ? new Error(error.message) : null };
+	}, []);
+
+	const signUp = useCallback(async (email: string, password: string) => {
+		const supabase = createClient();
+		const { error } = await supabase.auth.signUp({
+			email,
+			password,
+			options: {
+				emailRedirectTo: `${window.location.origin}/auth/callback`,
+			},
+		});
+		return { error: error ? new Error(error.message) : null };
+	}, []);
+
+	const signOut = useCallback(async () => {
+		const supabase = createClient();
+		await supabase.auth.signOut();
+	}, []);
+
+	return {
+		user,
+		loading,
+		signInWithOAuth,
+		signInWithMagicLink,
+		signInWithPassword,
+		signUp,
+		signOut,
+	};
+}

--- a/src/lib/supabase/client.test.ts
+++ b/src/lib/supabase/client.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Tests for Supabase browser client utility.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@supabase/ssr', () => ({
+	createBrowserClient: vi.fn(() => ({
+		auth: { getSession: vi.fn() },
+		from: vi.fn(),
+	})),
+}));
+
+describe('createClient (browser)', () => {
+	it('exports createClient function', async () => {
+		const mod = await import('./client');
+		expect(mod.createClient).toBeDefined();
+		expect(typeof mod.createClient).toBe('function');
+	});
+
+	it('returns a Supabase client', async () => {
+		const { createClient } = await import('./client');
+		const client = createClient();
+		expect(client).toBeDefined();
+		expect(client.auth).toBeDefined();
+	});
+
+	it('calls createBrowserClient from @supabase/ssr', async () => {
+		const { createBrowserClient } = await import('@supabase/ssr');
+		const { createClient } = await import('./client');
+		createClient();
+		expect(createBrowserClient).toHaveBeenCalled();
+	});
+});

--- a/src/lib/supabase/client.ts
+++ b/src/lib/supabase/client.ts
@@ -1,0 +1,17 @@
+/**
+ * Supabase browser client for Client Components.
+ *
+ * Uses `createBrowserClient` from @supabase/ssr for
+ * cookie-based session management in the browser.
+ *
+ * Spec reference: Section 4 (Auth)
+ */
+
+import { createBrowserClient } from '@supabase/ssr';
+
+export function createClient() {
+	return createBrowserClient(
+		process.env.NEXT_PUBLIC_SUPABASE_URL!,
+		process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+	);
+}

--- a/src/lib/supabase/middleware.test.ts
+++ b/src/lib/supabase/middleware.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Tests for Supabase middleware helper (session refresh on request).
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@supabase/ssr', () => ({
+	createServerClient: vi.fn(() => ({
+		auth: { getUser: vi.fn(() => Promise.resolve({ data: { user: null }, error: null })) },
+	})),
+}));
+
+describe('updateSession', () => {
+	it('exports updateSession function', async () => {
+		const mod = await import('./middleware');
+		expect(mod.updateSession).toBeDefined();
+		expect(typeof mod.updateSession).toBe('function');
+	});
+
+	it('returns a NextResponse', async () => {
+		const { NextRequest, NextResponse } = await import('next/server');
+		const { updateSession } = await import('./middleware');
+
+		const request = new NextRequest(new URL('http://localhost:3000/dashboard'));
+		const response = await updateSession(request);
+
+		expect(response).toBeInstanceOf(NextResponse);
+	});
+
+	it('redirects to login for protected routes when not authenticated', async () => {
+		const { NextRequest } = await import('next/server');
+		const { updateSession } = await import('./middleware');
+
+		const request = new NextRequest(new URL('http://localhost:3000/editor/abc'));
+		const response = await updateSession(request);
+
+		// Protected routes redirect to login when no user
+		expect(response.status).toBe(307);
+		expect(response.headers.get('location')).toContain('/login');
+	});
+
+	it('allows public routes without auth', async () => {
+		const { NextRequest } = await import('next/server');
+		const { updateSession } = await import('./middleware');
+
+		const request = new NextRequest(new URL('http://localhost:3000/'));
+		const response = await updateSession(request);
+
+		expect(response.status).toBe(200);
+	});
+});

--- a/src/lib/supabase/middleware.ts
+++ b/src/lib/supabase/middleware.ts
@@ -1,0 +1,71 @@
+/**
+ * Supabase middleware helper — refreshes session on every request.
+ *
+ * Called from Next.js middleware to keep the Supabase
+ * session alive and redirect unauthenticated users
+ * away from protected routes.
+ *
+ * Spec reference: Section 4 (Auth), Section 13 (Infrastructure)
+ */
+
+import { createServerClient } from '@supabase/ssr';
+import { type NextRequest, NextResponse } from 'next/server';
+
+const PROTECTED_ROUTES = ['/editor', '/dashboard', '/profile'];
+const AUTH_ROUTES = ['/login', '/signup'];
+
+function isProtectedRoute(pathname: string): boolean {
+	return PROTECTED_ROUTES.some((route) => pathname.startsWith(route));
+}
+
+function isAuthRoute(pathname: string): boolean {
+	return AUTH_ROUTES.some((route) => pathname.startsWith(route));
+}
+
+export async function updateSession(request: NextRequest): Promise<NextResponse> {
+	let supabaseResponse = NextResponse.next({ request });
+
+	const supabase = createServerClient(
+		process.env.NEXT_PUBLIC_SUPABASE_URL!,
+		process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+		{
+			cookies: {
+				getAll() {
+					return request.cookies.getAll();
+				},
+				setAll(cookiesToSet) {
+					for (const { name, value } of cookiesToSet) {
+						request.cookies.set(name, value);
+					}
+					supabaseResponse = NextResponse.next({ request });
+					for (const { name, value, options } of cookiesToSet) {
+						supabaseResponse.cookies.set(name, value, options);
+					}
+				},
+			},
+		},
+	);
+
+	const {
+		data: { user },
+	} = await supabase.auth.getUser();
+
+	const { pathname } = request.nextUrl;
+
+	// Redirect unauthenticated users from protected routes to login
+	if (!user && isProtectedRoute(pathname)) {
+		const loginUrl = request.nextUrl.clone();
+		loginUrl.pathname = '/login';
+		loginUrl.searchParams.set('redirect', pathname);
+		return NextResponse.redirect(loginUrl);
+	}
+
+	// Redirect authenticated users from auth routes to dashboard
+	if (user && isAuthRoute(pathname)) {
+		const dashboardUrl = request.nextUrl.clone();
+		dashboardUrl.pathname = '/dashboard';
+		return NextResponse.redirect(dashboardUrl);
+	}
+
+	return supabaseResponse;
+}

--- a/src/lib/supabase/server.test.ts
+++ b/src/lib/supabase/server.test.ts
@@ -1,0 +1,41 @@
+/**
+ * Tests for Supabase server client utility.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@supabase/ssr', () => ({
+	createServerClient: vi.fn(() => ({
+		auth: { getUser: vi.fn() },
+		from: vi.fn(),
+	})),
+}));
+
+vi.mock('next/headers', () => ({
+	cookies: vi.fn(() => ({
+		getAll: vi.fn(() => []),
+		set: vi.fn(),
+	})),
+}));
+
+describe('createServerSupabaseClient', () => {
+	it('exports createServerSupabaseClient function', async () => {
+		const mod = await import('./server');
+		expect(mod.createServerSupabaseClient).toBeDefined();
+		expect(typeof mod.createServerSupabaseClient).toBe('function');
+	});
+
+	it('returns a Supabase client', async () => {
+		const { createServerSupabaseClient } = await import('./server');
+		const client = await createServerSupabaseClient();
+		expect(client).toBeDefined();
+		expect(client.auth).toBeDefined();
+	});
+
+	it('calls createServerClient from @supabase/ssr', async () => {
+		const { createServerClient } = await import('@supabase/ssr');
+		const { createServerSupabaseClient } = await import('./server');
+		await createServerSupabaseClient();
+		expect(createServerClient).toHaveBeenCalled();
+	});
+});

--- a/src/lib/supabase/server.ts
+++ b/src/lib/supabase/server.ts
@@ -1,0 +1,37 @@
+/**
+ * Supabase server client for Server Components, Route Handlers, and Server Actions.
+ *
+ * Uses `createServerClient` from @supabase/ssr with Next.js
+ * cookie management for secure session handling.
+ *
+ * Spec reference: Section 4 (Auth)
+ */
+
+import { createServerClient } from '@supabase/ssr';
+import { cookies } from 'next/headers';
+
+export async function createServerSupabaseClient() {
+	const cookieStore = await cookies();
+
+	return createServerClient(
+		process.env.NEXT_PUBLIC_SUPABASE_URL!,
+		process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY!,
+		{
+			cookies: {
+				getAll() {
+					return cookieStore.getAll();
+				},
+				setAll(cookiesToSet) {
+					for (const { name, value, options } of cookiesToSet) {
+						try {
+							cookieStore.set(name, value, options);
+						} catch {
+							// Server Component context — cookies are read-only.
+							// Middleware handles refresh instead.
+						}
+					}
+				},
+			},
+		},
+	);
+}

--- a/src/middleware.test.ts
+++ b/src/middleware.test.ts
@@ -1,0 +1,34 @@
+/**
+ * Tests for Next.js root middleware.
+ */
+
+import { describe, expect, it, vi } from 'vitest';
+
+vi.mock('@/lib/supabase/middleware', () => ({
+	updateSession: vi.fn(() => new Response()),
+}));
+
+describe('middleware', () => {
+	it('exports middleware function', async () => {
+		const mod = await import('./middleware');
+		expect(mod.middleware).toBeDefined();
+		expect(typeof mod.middleware).toBe('function');
+	});
+
+	it('exports config with matcher', async () => {
+		const mod = await import('./middleware');
+		expect(mod.config).toBeDefined();
+		expect(mod.config.matcher).toBeDefined();
+		expect(Array.isArray(mod.config.matcher)).toBe(true);
+	});
+
+	it('calls updateSession with the request', async () => {
+		const { updateSession } = await import('@/lib/supabase/middleware');
+		const { middleware } = await import('./middleware');
+
+		const mockRequest = { nextUrl: { pathname: '/dashboard' } } as never;
+		await middleware(mockRequest);
+
+		expect(updateSession).toHaveBeenCalledWith(mockRequest);
+	});
+});

--- a/src/middleware.ts
+++ b/src/middleware.ts
@@ -1,0 +1,28 @@
+/**
+ * Next.js root middleware — delegates to Supabase session refresh.
+ *
+ * Runs on every matching request to keep auth sessions alive
+ * and protect routes that require authentication.
+ *
+ * Spec reference: Section 4 (Auth), Section 13 (Infrastructure)
+ */
+
+import type { NextRequest } from 'next/server';
+import { updateSession } from '@/lib/supabase/middleware';
+
+export async function middleware(request: NextRequest) {
+	return updateSession(request);
+}
+
+export const config = {
+	matcher: [
+		/*
+		 * Match all routes except:
+		 * - _next/static (static files)
+		 * - _next/image (image optimization)
+		 * - favicon.ico, sitemap.xml, robots.txt (metadata)
+		 * - Public assets in /images, /fonts, etc.
+		 */
+		'/((?!_next/static|_next/image|favicon.ico|sitemap.xml|robots.txt|images/|fonts/).*)',
+	],
+};


### PR DESCRIPTION
## Summary
- Implements complete Supabase Auth integration using `@supabase/ssr` for cookie-based session management in Next.js 16 App Router
- Adds browser client (`createClient`), server client (`createServerSupabaseClient`), and middleware session refresh with route protection
- Provides `useAuth` hook with OAuth (Google/GitHub), magic link, email/password sign-in, sign-up, and sign-out
- Creates auth callback route handler for OAuth code exchange (PKCE flow)
- Updates login/signup pages with real forms using shadcn/ui components (Input, Button, Label, Separator)

## Implementation Details
| File | Purpose |
|---|---|
| `src/lib/supabase/client.ts` | Browser Supabase client via `createBrowserClient` |
| `src/lib/supabase/server.ts` | Server Supabase client via `createServerClient` with cookies |
| `src/lib/supabase/middleware.ts` | Session refresh + route protection (protected/auth routes) |
| `src/middleware.ts` | Next.js root middleware delegates to `updateSession()` |
| `src/app/auth/callback/route.ts` | OAuth code exchange route handler |
| `src/hooks/use-auth.ts` | Client-side auth hook with all auth methods |
| `src/components/auth/login-form.tsx` | Login form (email/password + magic link) |
| `src/components/auth/signup-form.tsx` | Signup form (email/password) |
| `src/components/auth/oauth-buttons.tsx` | Shared OAuth buttons (Google, GitHub) |

## Test plan
- [x] 39 new auth tests pass (9 test files)
- [x] All 1442 tests pass across 106 files
- [x] TypeScript strict mode clean (`tsc --noEmit`)
- [x] Biome formatting applied (no new errors)
- [x] Browser client creates Supabase instance with env vars
- [x] Server client uses cookies from `next/headers`
- [x] Middleware redirects unauthenticated users from `/editor`, `/dashboard`, `/profile`
- [x] Middleware redirects authenticated users away from `/login`, `/signup`
- [x] Auth callback exchanges code for session and redirects
- [x] Login form renders email, password, magic link, and OAuth options
- [x] Signup form renders email, password, and OAuth options

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)