### PR TITLE
feat: set up Supabase database schema and RLS policies (#57)

### DIFF
--- a/src/lib/supabase/database.types.test.ts
+++ b/src/lib/supabase/database.types.test.ts
@@ -1,0 +1,171 @@
+/**
+ * Tests for database types — validates type structure and exports.
+ */
+
+import { describe, expect, it } from 'vitest';
+import type {
+	Database,
+	DbProject,
+	DbProjectInsert,
+	DbProjectUpdate,
+	DbScene,
+	DbSceneInsert,
+	DbSceneUpdate,
+	DbTemplate,
+	DbTemplateInsert,
+	StorageBucket,
+	TemplateCategory,
+	TemplateDifficulty,
+} from './database.types';
+
+describe('database.types', () => {
+	it('exports DbProject type with required fields', () => {
+		const project: DbProject = {
+			id: 'uuid-1',
+			user_id: 'user-1',
+			name: 'Test Project',
+			description: 'A test',
+			thumbnail_url: null,
+			is_public: false,
+			tags: ['sorting'],
+			settings: { canvasWidth: 1920 },
+			created_at: '2026-01-01T00:00:00Z',
+			updated_at: '2026-01-01T00:00:00Z',
+		};
+		expect(project.id).toBe('uuid-1');
+		expect(project.user_id).toBe('user-1');
+	});
+
+	it('exports DbProjectInsert without id and timestamps', () => {
+		const insert: DbProjectInsert = {
+			user_id: 'user-1',
+			name: 'New Project',
+			description: '',
+			thumbnail_url: null,
+			is_public: false,
+			tags: [],
+			settings: {},
+		};
+		expect(insert.name).toBe('New Project');
+	});
+
+	it('exports DbProjectUpdate as partial', () => {
+		const update: DbProjectUpdate = {
+			name: 'Updated Name',
+		};
+		expect(update.name).toBe('Updated Name');
+	});
+
+	it('exports DbScene type with required fields', () => {
+		const scene: DbScene = {
+			id: 'uuid-2',
+			project_id: 'uuid-1',
+			name: 'Scene 1',
+			scene_order: 0,
+			data: { elements: {} },
+			code_source: null,
+			duration: 5.0,
+			created_at: '2026-01-01T00:00:00Z',
+			updated_at: '2026-01-01T00:00:00Z',
+		};
+		expect(scene.project_id).toBe('uuid-1');
+		expect(scene.duration).toBe(5.0);
+	});
+
+	it('exports DbSceneInsert and DbSceneUpdate', () => {
+		const insert: DbSceneInsert = {
+			project_id: 'uuid-1',
+			name: 'Scene 2',
+			scene_order: 1,
+			data: {},
+			code_source: null,
+			duration: 0,
+		};
+		expect(insert.scene_order).toBe(1);
+
+		const update: DbSceneUpdate = { name: 'Renamed Scene' };
+		expect(update.name).toBe('Renamed Scene');
+	});
+
+	it('exports DbTemplate type with required fields', () => {
+		const template: DbTemplate = {
+			id: 'uuid-3',
+			name: 'Bubble Sort',
+			description: 'Classic sorting algorithm',
+			category: 'sorting',
+			difficulty: 'beginner',
+			thumbnail_url: null,
+			scene_data: {},
+			tags: ['sorting', 'comparison'],
+			usage_count: 42,
+			created_at: '2026-01-01T00:00:00Z',
+			updated_at: '2026-01-01T00:00:00Z',
+		};
+		expect(template.usage_count).toBe(42);
+	});
+
+	it('exports DbTemplateInsert without auto-generated fields', () => {
+		const insert: DbTemplateInsert = {
+			name: 'Quick Sort',
+			description: 'Efficient divide-and-conquer',
+			category: 'sorting',
+			difficulty: 'intermediate',
+			thumbnail_url: null,
+			scene_data: {},
+			tags: [],
+		};
+		expect(insert.category).toBe('sorting');
+	});
+
+	it('exports TemplateCategory union type', () => {
+		const categories: TemplateCategory[] = [
+			'sorting',
+			'searching',
+			'graph',
+			'tree',
+			'dynamic-programming',
+			'data-structure',
+			'string',
+			'math',
+			'other',
+		];
+		expect(categories).toHaveLength(9);
+	});
+
+	it('exports TemplateDifficulty union type', () => {
+		const difficulties: TemplateDifficulty[] = ['beginner', 'intermediate', 'advanced'];
+		expect(difficulties).toHaveLength(3);
+	});
+
+	it('exports StorageBucket union type', () => {
+		const buckets: StorageBucket[] = ['project-assets', 'exported-media', 'template-assets'];
+		expect(buckets).toHaveLength(3);
+	});
+
+	it('exports Database schema type', () => {
+		const _db: Database = {
+			public: {
+				Tables: {
+					projects: {
+						Row: {} as DbProject,
+						Insert: {} as DbProjectInsert,
+						Update: {} as DbProjectUpdate,
+					},
+					scenes: {
+						Row: {} as DbScene,
+						Insert: {} as DbSceneInsert,
+						Update: {} as DbSceneUpdate,
+					},
+					templates: {
+						Row: {} as DbTemplate,
+						Insert: {} as DbTemplateInsert,
+						Update: {} as Partial<DbTemplate>,
+					},
+				},
+			},
+		};
+		expect(_db.public.Tables.projects).toBeDefined();
+		expect(_db.public.Tables.scenes).toBeDefined();
+		expect(_db.public.Tables.templates).toBeDefined();
+	});
+});

--- a/src/lib/supabase/database.types.ts
+++ b/src/lib/supabase/database.types.ts
@@ -1,0 +1,104 @@
+/**
+ * Database types for Supabase PostgreSQL schema.
+ *
+ * These types mirror the database tables and are used
+ * for type-safe queries with the Supabase client.
+ *
+ * Spec reference: Section 8.2 (Database Schema)
+ */
+
+import type { JsonValue } from '@/types/common';
+
+// ─── Projects ──────────────────────────────────────────
+
+export interface DbProject {
+	id: string;
+	user_id: string;
+	name: string;
+	description: string;
+	thumbnail_url: string | null;
+	is_public: boolean;
+	tags: string[];
+	settings: Record<string, JsonValue>;
+	created_at: string;
+	updated_at: string;
+}
+
+export type DbProjectInsert = Omit<DbProject, 'id' | 'created_at' | 'updated_at'>;
+export type DbProjectUpdate = Partial<Omit<DbProject, 'id' | 'user_id' | 'created_at'>>;
+
+// ─── Scenes ────────────────────────────────────────────
+
+export interface DbScene {
+	id: string;
+	project_id: string;
+	name: string;
+	scene_order: number;
+	data: Record<string, JsonValue>;
+	code_source: Record<string, JsonValue> | null;
+	duration: number;
+	created_at: string;
+	updated_at: string;
+}
+
+export type DbSceneInsert = Omit<DbScene, 'id' | 'created_at' | 'updated_at'>;
+export type DbSceneUpdate = Partial<Omit<DbScene, 'id' | 'project_id' | 'created_at'>>;
+
+// ─── Templates ─────────────────────────────────────────
+
+export type TemplateCategory =
+	| 'sorting'
+	| 'searching'
+	| 'graph'
+	| 'tree'
+	| 'dynamic-programming'
+	| 'data-structure'
+	| 'string'
+	| 'math'
+	| 'other';
+
+export type TemplateDifficulty = 'beginner' | 'intermediate' | 'advanced';
+
+export interface DbTemplate {
+	id: string;
+	name: string;
+	description: string;
+	category: TemplateCategory;
+	difficulty: TemplateDifficulty;
+	thumbnail_url: string | null;
+	scene_data: Record<string, JsonValue>;
+	tags: string[];
+	usage_count: number;
+	created_at: string;
+	updated_at: string;
+}
+
+export type DbTemplateInsert = Omit<DbTemplate, 'id' | 'usage_count' | 'created_at' | 'updated_at'>;
+
+// ─── Database Schema ───────────────────────────────────
+
+export interface Database {
+	public: {
+		Tables: {
+			projects: {
+				Row: DbProject;
+				Insert: DbProjectInsert;
+				Update: DbProjectUpdate;
+			};
+			scenes: {
+				Row: DbScene;
+				Insert: DbSceneInsert;
+				Update: DbSceneUpdate;
+			};
+			templates: {
+				Row: DbTemplate;
+				Insert: DbTemplateInsert;
+				Update: Partial<DbTemplate>;
+			};
+		};
+	};
+}
+
+// ─── Storage Buckets ───────────────────────────────────
+
+export type StorageBucket = 'project-assets' | 'exported-media' | 'template-assets';

--- a/src/lib/supabase/queries.test.ts
+++ b/src/lib/supabase/queries.test.ts
@@ -1,0 +1,195 @@
+/**
+ * Tests for Supabase query helpers.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { describe, expect, it, vi } from 'vitest';
+
+// Chain builder mock — each call returns `this` for fluent API
+function createChainMock(finalResult: unknown = { data: [], error: null }) {
+	const chain: Record<string, ReturnType<typeof vi.fn>> = {};
+	const handler: ProxyHandler<Record<string, ReturnType<typeof vi.fn>>> = {
+		get(_target, prop: string) {
+			if (prop === 'then') return undefined; // Prevent Promise resolution
+			if (!chain[prop]) {
+				chain[prop] = vi.fn(() => {
+					// Terminal methods return the result
+					if (prop === 'single' || prop === 'returns' || prop === 'rpc') {
+						return Promise.resolve(finalResult);
+					}
+					return new Proxy(chain, handler);
+				});
+			}
+			return chain[prop];
+		},
+	};
+	return new Proxy(chain, handler);
+}
+
+function createMockClient(finalResult?: unknown): SupabaseClient {
+	const chain = createChainMock(finalResult);
+	return {
+		from: vi.fn(() => chain),
+		rpc: vi.fn(() => Promise.resolve({ data: null, error: null })),
+	} as unknown as SupabaseClient;
+}
+
+describe('query helpers', () => {
+	describe('project queries', () => {
+		it('getProjects queries by user_id', async () => {
+			const client = createMockClient();
+			const { getProjects } = await import('./queries');
+
+			await getProjects(client, 'user-123');
+
+			expect(client.from).toHaveBeenCalledWith('projects');
+		});
+
+		it('getProject queries by id', async () => {
+			const client = createMockClient();
+			const { getProject } = await import('./queries');
+
+			await getProject(client, 'project-1');
+
+			expect(client.from).toHaveBeenCalledWith('projects');
+		});
+
+		it('getPublicProjects filters by is_public', async () => {
+			const client = createMockClient();
+			const { getPublicProjects } = await import('./queries');
+
+			await getPublicProjects(client);
+
+			expect(client.from).toHaveBeenCalledWith('projects');
+		});
+
+		it('createProject inserts into projects table', async () => {
+			const client = createMockClient();
+			const { createProject } = await import('./queries');
+
+			await createProject(client, {
+				user_id: 'user-1',
+				name: 'Test',
+				description: '',
+				thumbnail_url: null,
+				is_public: false,
+				tags: [],
+				settings: {},
+			});
+
+			expect(client.from).toHaveBeenCalledWith('projects');
+		});
+
+		it('updateProject updates by id', async () => {
+			const client = createMockClient();
+			const { updateProject } = await import('./queries');
+
+			await updateProject(client, 'project-1', { name: 'Updated' });
+
+			expect(client.from).toHaveBeenCalledWith('projects');
+		});
+
+		it('deleteProject deletes by id', async () => {
+			const client = createMockClient();
+			const { deleteProject } = await import('./queries');
+
+			await deleteProject(client, 'project-1');
+
+			expect(client.from).toHaveBeenCalledWith('projects');
+		});
+	});
+
+	describe('scene queries', () => {
+		it('getScenes queries by project_id', async () => {
+			const client = createMockClient();
+			const { getScenes } = await import('./queries');
+
+			await getScenes(client, 'project-1');
+
+			expect(client.from).toHaveBeenCalledWith('scenes');
+		});
+
+		it('getScene queries by id', async () => {
+			const client = createMockClient();
+			const { getScene } = await import('./queries');
+
+			await getScene(client, 'scene-1');
+
+			expect(client.from).toHaveBeenCalledWith('scenes');
+		});
+
+		it('createScene inserts into scenes table', async () => {
+			const client = createMockClient();
+			const { createScene } = await import('./queries');
+
+			await createScene(client, {
+				project_id: 'project-1',
+				name: 'Scene 1',
+				scene_order: 0,
+				data: {},
+				code_source: null,
+				duration: 0,
+			});
+
+			expect(client.from).toHaveBeenCalledWith('scenes');
+		});
+
+		it('updateScene updates by id', async () => {
+			const client = createMockClient();
+			const { updateScene } = await import('./queries');
+
+			await updateScene(client, 'scene-1', { name: 'Renamed' });
+
+			expect(client.from).toHaveBeenCalledWith('scenes');
+		});
+
+		it('deleteScene deletes by id', async () => {
+			const client = createMockClient();
+			const { deleteScene } = await import('./queries');
+
+			await deleteScene(client, 'scene-1');
+
+			expect(client.from).toHaveBeenCalledWith('scenes');
+		});
+	});
+
+	describe('template queries', () => {
+		it('getTemplates queries all templates', async () => {
+			const client = createMockClient();
+			const { getTemplates } = await import('./queries');
+
+			await getTemplates(client);
+
+			expect(client.from).toHaveBeenCalledWith('templates');
+		});
+
+		it('getTemplates filters by category when provided', async () => {
+			const client = createMockClient();
+			const { getTemplates } = await import('./queries');
+
+			await getTemplates(client, 'sorting');
+
+			expect(client.from).toHaveBeenCalledWith('templates');
+		});
+
+		it('getTemplate queries by id', async () => {
+			const client = createMockClient();
+			const { getTemplate } = await import('./queries');
+
+			await getTemplate(client, 'template-1');
+
+			expect(client.from).toHaveBeenCalledWith('templates');
+		});
+
+		it('incrementTemplateUsage calls rpc', async () => {
+			const client = createMockClient();
+			const { incrementTemplateUsage } = await import('./queries');
+
+			await incrementTemplateUsage(client, 'template-1');
+
+			expect(client.rpc).toHaveBeenCalledWith('increment_template_usage', {
+				template_id: 'template-1',
+			});
+		});
+	});
+});

--- a/src/lib/supabase/queries.ts
+++ b/src/lib/supabase/queries.ts
@@ -1,0 +1,111 @@
+/**
+ * Typed Supabase query helpers for projects, scenes, and templates.
+ *
+ * Wraps common database operations with proper TypeScript types.
+ * All functions take a Supabase client instance for flexibility
+ * across server/client contexts.
+ *
+ * Spec reference: Section 8.2 (Database Schema)
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type {
+	DbProject,
+	DbProjectInsert,
+	DbProjectUpdate,
+	DbScene,
+	DbSceneInsert,
+	DbSceneUpdate,
+	DbTemplate,
+} from './database.types';
+
+// ─── Projects ──────────────────────────────────────────
+
+export async function getProjects(supabase: SupabaseClient, userId: string) {
+	return supabase
+		.from('projects')
+		.select('*')
+		.eq('user_id', userId)
+		.order('updated_at', { ascending: false })
+		.returns<DbProject[]>();
+}
+
+export async function getProject(supabase: SupabaseClient, projectId: string) {
+	return supabase.from('projects').select('*').eq('id', projectId).single<DbProject>();
+}
+
+export async function getPublicProjects(supabase: SupabaseClient) {
+	return supabase
+		.from('projects')
+		.select('*')
+		.eq('is_public', true)
+		.order('updated_at', { ascending: false })
+		.returns<DbProject[]>();
+}
+
+export async function createProject(supabase: SupabaseClient, project: DbProjectInsert) {
+	return supabase.from('projects').insert(project).select().single<DbProject>();
+}
+
+export async function updateProject(
+	supabase: SupabaseClient,
+	projectId: string,
+	updates: DbProjectUpdate,
+) {
+	return supabase.from('projects').update(updates).eq('id', projectId).select().single<DbProject>();
+}
+
+export async function deleteProject(supabase: SupabaseClient, projectId: string) {
+	return supabase.from('projects').delete().eq('id', projectId);
+}
+
+// ─── Scenes ────────────────────────────────────────────
+
+export async function getScenes(supabase: SupabaseClient, projectId: string) {
+	return supabase
+		.from('scenes')
+		.select('*')
+		.eq('project_id', projectId)
+		.order('scene_order', { ascending: true })
+		.returns<DbScene[]>();
+}
+
+export async function getScene(supabase: SupabaseClient, sceneId: string) {
+	return supabase.from('scenes').select('*').eq('id', sceneId).single<DbScene>();
+}
+
+export async function createScene(supabase: SupabaseClient, scene: DbSceneInsert) {
+	return supabase.from('scenes').insert(scene).select().single<DbScene>();
+}
+
+export async function updateScene(
+	supabase: SupabaseClient,
+	sceneId: string,
+	updates: DbSceneUpdate,
+) {
+	return supabase.from('scenes').update(updates).eq('id', sceneId).select().single<DbScene>();
+}
+
+export async function deleteScene(supabase: SupabaseClient, sceneId: string) {
+	return supabase.from('scenes').delete().eq('id', sceneId);
+}
+
+// ─── Templates ─────────────────────────────────────────
+
+export async function getTemplates(supabase: SupabaseClient, category?: string) {
+	let query = supabase.from('templates').select('*');
+
+	if (category) {
+		query = query.eq('category', category);
+	}
+
+	return query.order('usage_count', { ascending: false }).returns<DbTemplate[]>();
+}
+
+export async function getTemplate(supabase: SupabaseClient, templateId: string) {
+	return supabase.from('templates').select('*').eq('id', templateId).single<DbTemplate>();
+}
+
+export async function incrementTemplateUsage(supabase: SupabaseClient, templateId: string) {
+	return supabase.rpc('increment_template_usage', { template_id: templateId });
+}

--- a/src/lib/supabase/storage.test.ts
+++ b/src/lib/supabase/storage.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Tests for Supabase Storage helpers.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { describe, expect, it, vi } from 'vitest';
+import { deleteFile, getSignedUrl, uploadFile } from './storage';
+
+function createMockClient(overrides: Record<string, unknown> = {}): SupabaseClient {
+	const mockUpload = vi.fn(() => Promise.resolve({ data: { path: '' }, error: null }));
+	const mockGetPublicUrl = vi.fn(() => ({
+		data: { publicUrl: 'https://cdn.example.com/file.png' },
+	}));
+	const mockCreateSignedUrl = vi.fn(() =>
+		Promise.resolve({ data: { signedUrl: 'https://cdn.example.com/signed' }, error: null }),
+	);
+	const mockRemove = vi.fn(() => Promise.resolve({ data: [], error: null }));
+
+	return {
+		storage: {
+			from: vi.fn(() => ({
+				upload: mockUpload,
+				getPublicUrl: mockGetPublicUrl,
+				createSignedUrl: mockCreateSignedUrl,
+				remove: mockRemove,
+				...overrides,
+			})),
+		},
+	} as unknown as SupabaseClient;
+}
+
+describe('storage helpers', () => {
+	describe('uploadFile', () => {
+		it('uploads file with user-scoped path', async () => {
+			const client = createMockClient();
+			const file = new Blob(['test'], { type: 'text/plain' });
+
+			const result = await uploadFile(client, 'project-assets', 'user-123', 'image.png', file);
+
+			expect(result.error).toBeNull();
+			expect(result.data).not.toBeNull();
+			expect(result.data?.path).toBe('user-123/image.png');
+			expect(result.data?.url).toBe('https://cdn.example.com/file.png');
+		});
+
+		it('returns error on upload failure', async () => {
+			const client = createMockClient({
+				upload: vi.fn(() => Promise.resolve({ data: null, error: { message: 'Upload failed' } })),
+			});
+			const file = new Blob(['test']);
+
+			const result = await uploadFile(client, 'project-assets', 'user-123', 'file.png', file);
+
+			expect(result.data).toBeNull();
+			expect(result.error).not.toBeNull();
+			expect(result.error?.message).toBe('Upload failed');
+		});
+
+		it('calls storage.from with correct bucket', async () => {
+			const client = createMockClient();
+			const file = new Blob(['test']);
+
+			await uploadFile(client, 'exported-media', 'user-123', 'video.mp4', file);
+
+			expect(client.storage.from).toHaveBeenCalledWith('exported-media');
+		});
+	});
+
+	describe('getSignedUrl', () => {
+		it('returns signed URL for private file', async () => {
+			const client = createMockClient();
+
+			const result = await getSignedUrl(client, 'exported-media', 'user-123/video.mp4');
+
+			expect(result.error).toBeNull();
+			expect(result.url).toBe('https://cdn.example.com/signed');
+		});
+
+		it('returns error on failure', async () => {
+			const client = createMockClient({
+				createSignedUrl: vi.fn(() =>
+					Promise.resolve({ data: null, error: { message: 'Not found' } }),
+				),
+			});
+
+			const result = await getSignedUrl(client, 'exported-media', 'bad-path');
+
+			expect(result.url).toBeNull();
+			expect(result.error?.message).toBe('Not found');
+		});
+
+		it('uses default expiry of 3600 seconds', async () => {
+			const mockCreateSignedUrl = vi.fn(() =>
+				Promise.resolve({ data: { signedUrl: 'url' }, error: null }),
+			);
+			const client = createMockClient({ createSignedUrl: mockCreateSignedUrl });
+
+			await getSignedUrl(client, 'project-assets', 'path');
+
+			expect(mockCreateSignedUrl).toHaveBeenCalledWith('path', 3600);
+		});
+	});
+
+	describe('deleteFile', () => {
+		it('deletes file from bucket', async () => {
+			const client = createMockClient();
+
+			const result = await deleteFile(client, 'project-assets', 'user-123/old.png');
+
+			expect(result.error).toBeNull();
+		});
+
+		it('returns error on failure', async () => {
+			const client = createMockClient({
+				remove: vi.fn(() => Promise.resolve({ data: null, error: { message: 'Delete failed' } })),
+			});
+
+			const result = await deleteFile(client, 'project-assets', 'path');
+
+			expect(result.error?.message).toBe('Delete failed');
+		});
+	});
+});

--- a/src/lib/supabase/storage.ts
+++ b/src/lib/supabase/storage.ts
@@ -1,0 +1,82 @@
+/**
+ * Supabase Storage helpers for file upload/download.
+ *
+ * Provides typed wrappers around Supabase Storage for
+ * project assets, exported media, and template assets.
+ *
+ * Spec reference: Section 4 (Cloud Storage)
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { StorageBucket } from './database.types';
+
+export interface UploadResult {
+	path: string;
+	url: string;
+}
+
+/**
+ * Upload a file to a Supabase Storage bucket.
+ * Uses the user's ID as a path prefix for isolation.
+ */
+export async function uploadFile(
+	supabase: SupabaseClient,
+	bucket: StorageBucket,
+	userId: string,
+	fileName: string,
+	file: File | Blob,
+): Promise<{ data: UploadResult | null; error: Error | null }> {
+	const path = `${userId}/${fileName}`;
+
+	const { error } = await supabase.storage.from(bucket).upload(path, file, {
+		upsert: true,
+	});
+
+	if (error) {
+		return { data: null, error: new Error(error.message) };
+	}
+
+	const { data: urlData } = supabase.storage.from(bucket).getPublicUrl(path);
+
+	return {
+		data: { path, url: urlData.publicUrl },
+		error: null,
+	};
+}
+
+/**
+ * Get a signed URL for temporary access to a private file.
+ */
+export async function getSignedUrl(
+	supabase: SupabaseClient,
+	bucket: StorageBucket,
+	path: string,
+	expiresInSeconds = 3600,
+): Promise<{ url: string | null; error: Error | null }> {
+	const { data, error } = await supabase.storage
+		.from(bucket)
+		.createSignedUrl(path, expiresInSeconds);
+
+	if (error) {
+		return { url: null, error: new Error(error.message) };
+	}
+
+	return { url: data.signedUrl, error: null };
+}
+
+/**
+ * Delete a file from a Supabase Storage bucket.
+ */
+export async function deleteFile(
+	supabase: SupabaseClient,
+	bucket: StorageBucket,
+	path: string,
+): Promise<{ error: Error | null }> {
+	const { error } = await supabase.storage.from(bucket).remove([path]);
+
+	if (error) {
+		return { error: new Error(error.message) };
+	}
+
+	return { error: null };
+}

--- a/supabase/migrations/001_initial_schema.sql
+++ b/supabase/migrations/001_initial_schema.sql
@@ -1,0 +1,194 @@
+-- AlgoMotion initial database schema
+-- Migration: 001_initial_schema
+-- Spec reference: Section 8.2 (Database Schema)
+
+-- ═══════════════════════════════════════════════════════════
+-- TABLES
+-- ═══════════════════════════════════════════════════════════
+
+-- Projects table
+CREATE TABLE IF NOT EXISTS projects (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    user_id     UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+    name        TEXT NOT NULL DEFAULT 'Untitled Project',
+    description TEXT NOT NULL DEFAULT '',
+    thumbnail_url TEXT,
+    is_public   BOOLEAN NOT NULL DEFAULT false,
+    tags        TEXT[] NOT NULL DEFAULT '{}',
+    settings    JSONB NOT NULL DEFAULT '{}'::jsonb,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Scenes table
+CREATE TABLE IF NOT EXISTS scenes (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    project_id  UUID NOT NULL REFERENCES projects(id) ON DELETE CASCADE,
+    name        TEXT NOT NULL DEFAULT 'Scene 1',
+    scene_order INTEGER NOT NULL DEFAULT 0,
+    data        JSONB NOT NULL DEFAULT '{}'::jsonb,
+    code_source JSONB,
+    duration    REAL NOT NULL DEFAULT 0,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Templates table
+CREATE TABLE IF NOT EXISTS templates (
+    id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name           TEXT NOT NULL,
+    description    TEXT NOT NULL DEFAULT '',
+    category       TEXT NOT NULL DEFAULT 'other',
+    difficulty     TEXT NOT NULL DEFAULT 'beginner',
+    thumbnail_url  TEXT,
+    scene_data     JSONB NOT NULL DEFAULT '{}'::jsonb,
+    tags           TEXT[] NOT NULL DEFAULT '{}',
+    usage_count    INTEGER NOT NULL DEFAULT 0,
+    created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_at     TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- ═══════════════════════════════════════════════════════════
+-- INDEXES
+-- ═══════════════════════════════════════════════════════════
+
+-- Projects indexes
+CREATE INDEX IF NOT EXISTS idx_projects_user ON projects (user_id);
+CREATE INDEX IF NOT EXISTS idx_projects_public ON projects (created_at DESC) WHERE is_public = true;
+CREATE INDEX IF NOT EXISTS idx_projects_updated ON projects (updated_at DESC);
+CREATE INDEX IF NOT EXISTS idx_projects_tags ON projects USING GIN (tags);
+
+-- Scenes indexes
+CREATE INDEX IF NOT EXISTS idx_scenes_project ON scenes (project_id);
+CREATE INDEX IF NOT EXISTS idx_scenes_order ON scenes (project_id, scene_order);
+
+-- Templates indexes
+CREATE INDEX IF NOT EXISTS idx_templates_category ON templates (category);
+CREATE INDEX IF NOT EXISTS idx_templates_usage ON templates (usage_count DESC);
+
+-- ═══════════════════════════════════════════════════════════
+-- TRIGGERS: Auto-update updated_at
+-- ═══════════════════════════════════════════════════════════
+
+CREATE OR REPLACE FUNCTION update_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+    NEW.updated_at = now();
+    RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+CREATE TRIGGER trg_projects_updated_at
+    BEFORE UPDATE ON projects
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at();
+
+CREATE TRIGGER trg_scenes_updated_at
+    BEFORE UPDATE ON scenes
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at();
+
+CREATE TRIGGER trg_templates_updated_at
+    BEFORE UPDATE ON templates
+    FOR EACH ROW
+    EXECUTE FUNCTION update_updated_at();
+
+-- ═══════════════════════════════════════════════════════════
+-- ROW LEVEL SECURITY (RLS)
+-- ═══════════════════════════════════════════════════════════
+
+-- Enable RLS on all tables
+ALTER TABLE projects ENABLE ROW LEVEL SECURITY;
+ALTER TABLE scenes ENABLE ROW LEVEL SECURITY;
+ALTER TABLE templates ENABLE ROW LEVEL SECURITY;
+
+-- ─── Projects policies ─────────────────────────────────
+
+-- Users can read their own projects
+CREATE POLICY projects_select_own ON projects
+    FOR SELECT USING (auth.uid() = user_id);
+
+-- Public projects are viewable by anyone (authenticated)
+CREATE POLICY projects_select_public ON projects
+    FOR SELECT USING (is_public = true);
+
+-- Users can insert their own projects
+CREATE POLICY projects_insert_own ON projects
+    FOR INSERT WITH CHECK (auth.uid() = user_id);
+
+-- Users can update their own projects
+CREATE POLICY projects_update_own ON projects
+    FOR UPDATE USING (auth.uid() = user_id)
+    WITH CHECK (auth.uid() = user_id);
+
+-- Users can delete their own projects
+CREATE POLICY projects_delete_own ON projects
+    FOR DELETE USING (auth.uid() = user_id);
+
+-- ─── Scenes policies (inherit from project ownership) ──
+
+-- Users can read scenes of their own projects or public projects
+CREATE POLICY scenes_select ON scenes
+    FOR SELECT USING (
+        EXISTS (
+            SELECT 1 FROM projects
+            WHERE projects.id = scenes.project_id
+            AND (projects.user_id = auth.uid() OR projects.is_public = true)
+        )
+    );
+
+-- Users can insert scenes into their own projects
+CREATE POLICY scenes_insert ON scenes
+    FOR INSERT WITH CHECK (
+        EXISTS (
+            SELECT 1 FROM projects
+            WHERE projects.id = scenes.project_id
+            AND projects.user_id = auth.uid()
+        )
+    );
+
+-- Users can update scenes of their own projects
+CREATE POLICY scenes_update ON scenes
+    FOR UPDATE USING (
+        EXISTS (
+            SELECT 1 FROM projects
+            WHERE projects.id = scenes.project_id
+            AND projects.user_id = auth.uid()
+        )
+    );
+
+-- Users can delete scenes of their own projects
+CREATE POLICY scenes_delete ON scenes
+    FOR DELETE USING (
+        EXISTS (
+            SELECT 1 FROM projects
+            WHERE projects.id = scenes.project_id
+            AND projects.user_id = auth.uid()
+        )
+    );
+
+-- ─── Templates policies ────────────────────────────────
+
+-- All authenticated users can read templates
+CREATE POLICY templates_select_all ON templates
+    FOR SELECT USING (auth.role() = 'authenticated');
+
+-- ═══════════════════════════════════════════════════════════
+-- STORAGE BUCKETS
+-- ═══════════════════════════════════════════════════════════
+
+-- Note: Storage buckets and policies should be created via
+-- the Supabase Dashboard or CLI, as SQL for storage varies.
+-- The following are the bucket specifications:
+--
+-- 1. project-assets (private)
+--    - Purpose: Project thumbnails, user uploads
+--    - Policy: Users can upload/read files in their own path (user_id/*)
+--
+-- 2. exported-media (private)
+--    - Purpose: Exported videos, GIFs, PNGs
+--    - Policy: Users can upload/read files in their own path (user_id/*)
+--
+-- 3. template-assets (public)
+--    - Purpose: Template thumbnails and previews
+--    - Policy: Public read access, admin write only


### PR DESCRIPTION
## Summary
- Creates PostgreSQL schema migration with `projects`, `scenes`, and `templates` tables
- Implements Row Level Security (RLS) policies: users CRUD own projects, public read for shared projects, authenticated read for templates
- Adds optimized indexes: GIN for tags array, partial index for public projects, compound index for scene ordering
- Provides TypeScript database types (`DbProject`, `DbScene`, `DbTemplate`) with Insert/Update variants
- Implements typed query helpers for all CRUD operations with Supabase fluent API
- Adds Storage helpers (`uploadFile`, `getSignedUrl`, `deleteFile`) with user-scoped paths

## Implementation Details
| File | Purpose |
|---|---|
| `supabase/migrations/001_initial_schema.sql` | Full SQL migration (tables, indexes, triggers, RLS) |
| `src/lib/supabase/database.types.ts` | TypeScript types matching DB schema + Database type |
| `src/lib/supabase/queries.ts` | Typed CRUD helpers for projects, scenes, templates |
| `src/lib/supabase/storage.ts` | File upload/download helpers with signed URLs |

## Test plan
- [x] 34 new tests pass (3 test files)
- [x] All 1476 tests pass across 109 files
- [x] TypeScript strict mode clean (`tsc --noEmit`)
- [x] Biome formatting applied (no new errors)
- [x] Database types cover all table columns with proper optionality
- [x] Insert types omit auto-generated fields (id, timestamps)
- [x] Update types are properly partial
- [x] Query helpers call correct table names
- [x] Storage helpers scope paths by user ID
- [x] Signed URL generation with configurable expiry

Closes #57

🤖 Generated with [Claude Code](https://claude.com/claude-code)