### PR TITLE
feat: add accessibility audit and WCAG AA compliance (#62)

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -145,6 +145,56 @@
 	}
 }
 
+/* Accessibility — Focus indicators (2px visible outline, WCAG compliant) */
+@layer base {
+	:focus-visible {
+		outline: 2px solid var(--ring);
+		outline-offset: 2px;
+	}
+}
+
+/* Accessibility — Reduced motion: disable transitions and animations */
+@media (prefers-reduced-motion: reduce) {
+	*,
+	*::before,
+	*::after {
+		animation-duration: 0.01ms !important;
+		animation-iteration-count: 1 !important;
+		transition-duration: 0.01ms !important;
+		scroll-behavior: auto !important;
+	}
+}
+
+/* Accessibility — High contrast mode overrides */
+.high-contrast {
+	--foreground: hsl(0 0% 0%);
+	--background: hsl(0 0% 100%);
+	--muted-foreground: hsl(0 0% 20%);
+	--border: hsl(0 0% 0%);
+	--ring: hsl(0 0% 0%);
+}
+
+.dark.high-contrast {
+	--foreground: hsl(0 0% 100%);
+	--background: hsl(0 0% 0%);
+	--muted-foreground: hsl(0 0% 85%);
+	--border: hsl(0 0% 100%);
+	--ring: hsl(0 0% 100%);
+}
+
+/* Accessibility — Screen reader only utility */
+.sr-only {
+	position: absolute;
+	width: 1px;
+	height: 1px;
+	padding: 0;
+	margin: -1px;
+	overflow: hidden;
+	clip: rect(0, 0, 0, 0);
+	white-space: nowrap;
+	border-width: 0;
+}
+
 /* Monaco Editor — breakpoint glyph (red dot in gutter) */
 .breakpoint-glyph {
 	background: #ef4444;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,8 @@ import { Analytics } from '@vercel/analytics/next';
 import { SpeedInsights } from '@vercel/speed-insights/next';
 import type { Metadata } from 'next';
 import { Inter, JetBrains_Mono } from 'next/font/google';
+import { ScreenReaderAnnouncer } from '@/components/a11y/screen-reader-announcer';
+import { SkipToContent } from '@/components/a11y/skip-to-content';
 import { Providers } from '@/components/shared/providers';
 import './globals.css';
 
@@ -29,7 +31,11 @@ export default function RootLayout({
 	return (
 		<html lang="en" suppressHydrationWarning>
 			<body className={`${inter.variable} ${jetbrainsMono.variable} font-sans antialiased`}>
-				<Providers>{children}</Providers>
+				<SkipToContent />
+				<Providers>
+					<ScreenReaderAnnouncer />
+					{children}
+				</Providers>
 				<Analytics />
 				<SpeedInsights />
 			</body>

--- a/src/components/a11y/canvas-a11y-layer.test.tsx
+++ b/src/components/a11y/canvas-a11y-layer.test.tsx
@@ -1,0 +1,83 @@
+/**
+ * Tests for CanvasA11yLayer component.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { CanvasA11yLayer } from './canvas-a11y-layer';
+
+vi.mock('@/lib/stores/scene-store', () => ({
+	useSceneStore: vi.fn((selector: (s: unknown) => unknown) => {
+		const state = {
+			elements: {
+				el1: {
+					id: 'el1',
+					type: 'rect',
+					position: { x: 100, y: 200 },
+					label: 'Node A',
+				},
+				el2: {
+					id: 'el2',
+					type: 'ellipse',
+					position: { x: 300, y: 400 },
+				},
+			},
+			elementIds: ['el1', 'el2'],
+			selectedIds: ['el1'],
+		};
+		return selector(state);
+	}),
+}));
+
+vi.mock('@/lib/stores/timeline-store', () => ({
+	useTimelineStore: vi.fn((selector: (s: unknown) => unknown) => {
+		const state = {
+			playback: { status: 'stopped', currentTime: 0 },
+		};
+		return selector(state);
+	}),
+}));
+
+describe('CanvasA11yLayer', () => {
+	beforeEach(() => {
+		vi.clearAllMocks();
+	});
+
+	it('renders a region for canvas description', () => {
+		render(<CanvasA11yLayer />);
+		const region = screen.getByRole('region', { name: 'Canvas scene description' });
+		expect(region).toBeDefined();
+	});
+
+	it('shows element count', () => {
+		render(<CanvasA11yLayer />);
+		expect(screen.getByText(/2 elements on canvas/)).toBeDefined();
+	});
+
+	it('shows selected count', () => {
+		render(<CanvasA11yLayer />);
+		expect(screen.getByText(/1 selected/)).toBeDefined();
+	});
+
+	it('lists scene elements with positions', () => {
+		render(<CanvasA11yLayer />);
+		expect(screen.getByText(/rect at \(100, 200\): Node A \(selected\)/)).toBeDefined();
+	});
+
+	it('renders elements without labels', () => {
+		render(<CanvasA11yLayer />);
+		expect(screen.getByText(/ellipse at \(300, 400\)/)).toBeDefined();
+	});
+
+	it('has sr-only class for visual hiding', () => {
+		render(<CanvasA11yLayer />);
+		const region = screen.getByRole('region', { name: 'Canvas scene description' });
+		expect(region.className).toContain('sr-only');
+	});
+
+	it('has aria-live polite', () => {
+		render(<CanvasA11yLayer />);
+		const region = screen.getByRole('region', { name: 'Canvas scene description' });
+		expect(region.getAttribute('aria-live')).toBe('polite');
+	});
+});

--- a/src/components/a11y/canvas-a11y-layer.tsx
+++ b/src/components/a11y/canvas-a11y-layer.tsx
@@ -1,0 +1,47 @@
+/**
+ * Accessible description layer for the Pixi.js canvas.
+ *
+ * Creates a parallel DOM that mirrors the canvas scene graph
+ * with ARIA attributes for screen reader navigation.
+ * Positioned absolutely behind the canvas, invisible visually
+ * but accessible to assistive technologies.
+ *
+ * Spec reference: Section 11 (Accessibility — Parallel DOM)
+ */
+
+'use client';
+
+import { useSceneStore } from '@/lib/stores/scene-store';
+import { useTimelineStore } from '@/lib/stores/timeline-store';
+
+export function CanvasA11yLayer() {
+	const elements = useSceneStore((s) => s.elements);
+	const elementIds = useSceneStore((s) => s.elementIds);
+	const selectedIds = useSceneStore((s) => s.selectedIds);
+	const status = useTimelineStore((s) => s.playback.status);
+	const currentTime = useTimelineStore((s) => s.playback.currentTime);
+
+	return (
+		<section className="sr-only" aria-label="Canvas scene description" aria-live="polite">
+			<p>
+				Animation {status}. {elementIds.length} elements on canvas.
+				{selectedIds.length > 0 && ` ${selectedIds.length} selected.`}
+				{status === 'playing' && ` Time: ${currentTime.toFixed(1)}s.`}
+			</p>
+			<ul aria-label="Scene elements">
+				{elementIds.map((id) => {
+					const el = elements[id];
+					if (!el) return null;
+					const isSelected = selectedIds.includes(id);
+					return (
+						<li key={id}>
+							{el.type} at ({Math.round(el.position.x)}, {Math.round(el.position.y)})
+							{el.label ? `: ${el.label}` : ''}
+							{isSelected ? ' (selected)' : ''}
+						</li>
+					);
+				})}
+			</ul>
+		</section>
+	);
+}

--- a/src/components/a11y/screen-reader-announcer.test.tsx
+++ b/src/components/a11y/screen-reader-announcer.test.tsx
@@ -1,0 +1,44 @@
+/**
+ * Tests for ScreenReaderAnnouncer component.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { beforeEach, describe, expect, it } from 'vitest';
+import { useAnnouncerStore } from '@/lib/stores/announcer-store';
+import { ScreenReaderAnnouncer } from './screen-reader-announcer';
+
+describe('ScreenReaderAnnouncer', () => {
+	beforeEach(() => {
+		useAnnouncerStore.getState().clear();
+	});
+
+	it('renders polite and assertive live regions', () => {
+		render(<ScreenReaderAnnouncer />);
+		expect(screen.getByRole('status')).toBeDefined();
+		expect(screen.getByRole('alert')).toBeDefined();
+	});
+
+	it('has aria-live polite on status region', () => {
+		render(<ScreenReaderAnnouncer />);
+		const status = screen.getByRole('status');
+		expect(status.getAttribute('aria-live')).toBe('polite');
+	});
+
+	it('has aria-live assertive on alert region', () => {
+		render(<ScreenReaderAnnouncer />);
+		const alert = screen.getByRole('alert');
+		expect(alert.getAttribute('aria-live')).toBe('assertive');
+	});
+
+	it('has aria-atomic true on both regions', () => {
+		render(<ScreenReaderAnnouncer />);
+		expect(screen.getByRole('status').getAttribute('aria-atomic')).toBe('true');
+		expect(screen.getByRole('alert').getAttribute('aria-atomic')).toBe('true');
+	});
+
+	it('regions are visually hidden with sr-only', () => {
+		render(<ScreenReaderAnnouncer />);
+		const status = screen.getByRole('status');
+		expect(status.className).toContain('sr-only');
+	});
+});

--- a/src/components/a11y/screen-reader-announcer.tsx
+++ b/src/components/a11y/screen-reader-announcer.tsx
@@ -1,0 +1,49 @@
+/**
+ * Invisible ARIA live region for screen reader announcements.
+ *
+ * Provides polite and assertive announcement channels.
+ * Must remain mounted in the DOM at all times — content
+ * is changed dynamically, never conditionally rendered.
+ *
+ * Spec reference: Section 11 (Accessibility Requirements)
+ */
+
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { useAnnouncerStore } from '@/lib/stores/announcer-store';
+
+export function ScreenReaderAnnouncer() {
+	const politeRef = useRef<HTMLOutputElement>(null);
+	const assertiveRef = useRef<HTMLDivElement>(null);
+	const message = useAnnouncerStore((s) => s.message);
+	const priority = useAnnouncerStore((s) => s.priority);
+	const version = useAnnouncerStore((s) => s.version);
+
+	// biome-ignore lint/correctness/useExhaustiveDependencies: version forces re-announcement of identical messages
+	useEffect(() => {
+		if (!message) return;
+
+		const target = priority === 'assertive' ? assertiveRef.current : politeRef.current;
+		if (target) {
+			// Clear then set to ensure screen readers detect the change
+			target.textContent = '';
+			requestAnimationFrame(() => {
+				target.textContent = message;
+			});
+		}
+	}, [message, priority, version]);
+
+	return (
+		<>
+			<output ref={politeRef} aria-live="polite" aria-atomic="true" className="sr-only" />
+			<div
+				ref={assertiveRef}
+				role="alert"
+				aria-live="assertive"
+				aria-atomic="true"
+				className="sr-only"
+			/>
+		</>
+	);
+}

--- a/src/components/a11y/skip-to-content.test.tsx
+++ b/src/components/a11y/skip-to-content.test.tsx
@@ -1,0 +1,27 @@
+/**
+ * Tests for SkipToContent component.
+ */
+
+import { render, screen } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { SkipToContent } from './skip-to-content';
+
+describe('SkipToContent', () => {
+	it('renders a skip link', () => {
+		render(<SkipToContent />);
+		const link = screen.getByText('Skip to main content');
+		expect(link).toBeDefined();
+	});
+
+	it('links to #main-content', () => {
+		render(<SkipToContent />);
+		const link = screen.getByText('Skip to main content');
+		expect(link.getAttribute('href')).toBe('#main-content');
+	});
+
+	it('is an anchor element', () => {
+		render(<SkipToContent />);
+		const link = screen.getByText('Skip to main content');
+		expect(link.tagName).toBe('A');
+	});
+});

--- a/src/components/a11y/skip-to-content.tsx
+++ b/src/components/a11y/skip-to-content.tsx
@@ -1,0 +1,19 @@
+/**
+ * Skip navigation link for keyboard users.
+ *
+ * Visually hidden until focused via Tab key, then appears
+ * at top of page allowing users to bypass navigation.
+ *
+ * Spec reference: Section 11 (Accessibility Requirements)
+ */
+
+export function SkipToContent() {
+	return (
+		<a
+			href="#main-content"
+			className="fixed top-0 left-0 z-[9999] -translate-y-full bg-primary px-4 py-2 text-sm text-primary-foreground transition-transform focus:translate-y-0"
+		>
+			Skip to main content
+		</a>
+	);
+}

--- a/src/components/canvas/pixi-canvas.tsx
+++ b/src/components/canvas/pixi-canvas.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useCallback, useEffect, useRef, useState } from 'react';
+import { CanvasA11yLayer } from '@/components/a11y/canvas-a11y-layer';
 import { useCanvasKeyboard } from '@/hooks/use-canvas-keyboard';
 import { SceneManager } from '@/lib/pixi/scene-manager';
 import { useSceneStore } from '@/lib/stores/scene-store';
@@ -197,6 +198,8 @@ export function PixiCanvas() {
 				role="application"
 				aria-label="Canvas workspace"
 			/>
+			{/* Accessible description of canvas contents for screen readers */}
+			<CanvasA11yLayer />
 		</div>
 	);
 }

--- a/src/components/editor/editor-layout.tsx
+++ b/src/components/editor/editor-layout.tsx
@@ -10,6 +10,7 @@ import { RightPanel } from '@/components/panels/right-panel';
 import { ResizableHandle, ResizablePanel, ResizablePanelGroup } from '@/components/ui/resizable';
 import { useAutoSave } from '@/hooks/use-auto-save';
 import { useGlobalShortcuts } from '@/hooks/use-global-shortcuts';
+import { usePlaybackAnnouncer } from '@/hooks/use-playback-announcer';
 import { useThemeSync } from '@/hooks/use-theme-sync';
 import { useUIStore } from '@/lib/stores/ui-store';
 import { CommandPalette } from './command-palette';
@@ -19,6 +20,7 @@ export function EditorLayout() {
 	useGlobalShortcuts();
 	useAutoSave();
 	useThemeSync();
+	usePlaybackAnnouncer();
 
 	const leftRef = usePanelRef();
 	const rightRef = usePanelRef();
@@ -81,7 +83,7 @@ export function EditorLayout() {
 	);
 
 	return (
-		<div className="flex h-screen flex-col overflow-hidden">
+		<main id="main-content" className="flex h-screen flex-col overflow-hidden">
 			<Toolbar />
 			<CommandPalette />
 			<ResizablePanelGroup orientation="horizontal" className="flex-1">
@@ -138,6 +140,6 @@ export function EditorLayout() {
 					<RightPanel />
 				</ResizablePanel>
 			</ResizablePanelGroup>
-		</div>
+		</main>
 	);
 }

--- a/src/hooks/use-playback-announcer.test.ts
+++ b/src/hooks/use-playback-announcer.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Tests for usePlaybackAnnouncer hook.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const mockAnnounce = vi.fn();
+
+vi.mock('@/lib/stores/announcer-store', () => ({
+	announce: (...args: unknown[]) => mockAnnounce(...args),
+}));
+
+let mockStatus = 'idle';
+
+vi.mock('@/lib/stores/timeline-store', () => ({
+	useTimelineStore: vi.fn((selector: (s: unknown) => unknown) => {
+		const state = {
+			playback: { status: mockStatus },
+		};
+		return selector(state);
+	}),
+}));
+
+// Must import after mocks
+const { usePlaybackAnnouncer } = await import('./use-playback-announcer');
+
+describe('usePlaybackAnnouncer', () => {
+	beforeEach(() => {
+		mockStatus = 'idle';
+		mockAnnounce.mockClear();
+	});
+
+	it('does not announce on initial idle state', () => {
+		renderHook(() => usePlaybackAnnouncer());
+		expect(mockAnnounce).not.toHaveBeenCalled();
+	});
+
+	it('announces when status changes to playing', () => {
+		mockStatus = 'idle';
+		const { rerender } = renderHook(() => usePlaybackAnnouncer());
+
+		mockStatus = 'playing';
+		rerender();
+
+		expect(mockAnnounce).toHaveBeenCalledWith('Animation playing');
+	});
+
+	it('announces when status changes to paused', () => {
+		mockStatus = 'playing';
+		const { rerender } = renderHook(() => usePlaybackAnnouncer());
+
+		mockStatus = 'paused';
+		rerender();
+
+		expect(mockAnnounce).toHaveBeenCalledWith('Animation paused');
+	});
+
+	it('announces when status changes to stopped', () => {
+		mockStatus = 'playing';
+		const { rerender } = renderHook(() => usePlaybackAnnouncer());
+
+		mockStatus = 'stopped';
+		rerender();
+
+		expect(mockAnnounce).toHaveBeenCalledWith('Animation stopped');
+	});
+});

--- a/src/hooks/use-playback-announcer.ts
+++ b/src/hooks/use-playback-announcer.ts
@@ -1,0 +1,37 @@
+/**
+ * Hook that announces playback state changes to screen readers.
+ *
+ * Subscribes to timeline store changes and announces
+ * play/pause/stop transitions via the announcer store.
+ *
+ * Spec reference: Section 11 (Screen reader announcements)
+ */
+
+'use client';
+
+import { useEffect, useRef } from 'react';
+import { announce } from '@/lib/stores/announcer-store';
+import { useTimelineStore } from '@/lib/stores/timeline-store';
+import type { PlaybackStatus } from '@/types';
+
+const STATUS_MESSAGES: Record<PlaybackStatus, string> = {
+	idle: '',
+	playing: 'Animation playing',
+	paused: 'Animation paused',
+	stopped: 'Animation stopped',
+};
+
+export function usePlaybackAnnouncer(): void {
+	const status = useTimelineStore((s) => s.playback.status);
+	const prevStatusRef = useRef<PlaybackStatus>(status);
+
+	useEffect(() => {
+		if (status !== prevStatusRef.current) {
+			prevStatusRef.current = status;
+			const message = STATUS_MESSAGES[status];
+			if (message) {
+				announce(message);
+			}
+		}
+	}, [status]);
+}

--- a/src/hooks/use-reduced-motion.test.ts
+++ b/src/hooks/use-reduced-motion.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Tests for useReducedMotion hook.
+ */
+
+import { renderHook } from '@testing-library/react';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { useReducedMotion } from './use-reduced-motion';
+
+describe('useReducedMotion', () => {
+	let matchMediaMock: ReturnType<typeof vi.fn>;
+	let listeners: Map<string, (e: MediaQueryListEvent) => void>;
+
+	beforeEach(() => {
+		listeners = new Map();
+		matchMediaMock = vi.fn((query: string) => ({
+			matches: false,
+			media: query,
+			addEventListener: vi.fn((_event: string, handler: (e: MediaQueryListEvent) => void) => {
+				listeners.set(_event, handler);
+			}),
+			removeEventListener: vi.fn(),
+			onchange: null,
+		}));
+		Object.defineProperty(window, 'matchMedia', {
+			writable: true,
+			value: matchMediaMock,
+		});
+	});
+
+	afterEach(() => {
+		vi.restoreAllMocks();
+	});
+
+	it('returns false when no preference is set', () => {
+		const { result } = renderHook(() => useReducedMotion());
+		expect(result.current).toBe(false);
+	});
+
+	it('returns true when reduced motion is preferred', () => {
+		matchMediaMock.mockReturnValue({
+			matches: true,
+			media: '(prefers-reduced-motion: reduce)',
+			addEventListener: vi.fn(),
+			removeEventListener: vi.fn(),
+		});
+
+		const { result } = renderHook(() => useReducedMotion());
+		expect(result.current).toBe(true);
+	});
+
+	it('registers a change listener on matchMedia', () => {
+		const addEventListener = vi.fn();
+		matchMediaMock.mockReturnValue({
+			matches: false,
+			media: '(prefers-reduced-motion: reduce)',
+			addEventListener,
+			removeEventListener: vi.fn(),
+		});
+
+		renderHook(() => useReducedMotion());
+		expect(addEventListener).toHaveBeenCalledWith('change', expect.any(Function));
+	});
+
+	it('cleans up listener on unmount', () => {
+		const removeEventListener = vi.fn();
+		matchMediaMock.mockReturnValue({
+			matches: false,
+			media: '(prefers-reduced-motion: reduce)',
+			addEventListener: vi.fn(),
+			removeEventListener,
+		});
+
+		const { unmount } = renderHook(() => useReducedMotion());
+		unmount();
+		expect(removeEventListener).toHaveBeenCalledWith('change', expect.any(Function));
+	});
+});

--- a/src/hooks/use-reduced-motion.ts
+++ b/src/hooks/use-reduced-motion.ts
@@ -1,0 +1,35 @@
+/**
+ * Hook for detecting the user's reduced motion preference.
+ *
+ * Listens to `prefers-reduced-motion` media query and
+ * provides a reactive boolean. Used by GSAP animation
+ * engine and CSS transitions to respect user preferences.
+ *
+ * Spec reference: Section 11 (Accessibility Requirements)
+ */
+
+'use client';
+
+import { useEffect, useState } from 'react';
+
+const MEDIA_QUERY = '(prefers-reduced-motion: reduce)';
+
+export function useReducedMotion(): boolean {
+	const [prefersReducedMotion, setPrefersReducedMotion] = useState(() => {
+		if (typeof window === 'undefined') return false;
+		return window.matchMedia(MEDIA_QUERY).matches;
+	});
+
+	useEffect(() => {
+		const mql = window.matchMedia(MEDIA_QUERY);
+
+		function handleChange(e: MediaQueryListEvent) {
+			setPrefersReducedMotion(e.matches);
+		}
+
+		mql.addEventListener('change', handleChange);
+		return () => mql.removeEventListener('change', handleChange);
+	}, []);
+
+	return prefersReducedMotion;
+}

--- a/src/lib/stores/announcer-store.test.ts
+++ b/src/lib/stores/announcer-store.test.ts
@@ -1,0 +1,61 @@
+/**
+ * Tests for announcer store.
+ */
+
+import { beforeEach, describe, expect, it } from 'vitest';
+import { announce, useAnnouncerStore } from './announcer-store';
+
+describe('announcerStore', () => {
+	beforeEach(() => {
+		useAnnouncerStore.getState().clear();
+	});
+
+	it('starts with empty message', () => {
+		const state = useAnnouncerStore.getState();
+		expect(state.message).toBe('');
+		expect(state.priority).toBe('polite');
+		expect(state.version).toBe(0);
+	});
+
+	it('announces a polite message', () => {
+		useAnnouncerStore.getState().announce('Step 1 of 5');
+		const state = useAnnouncerStore.getState();
+		expect(state.message).toBe('Step 1 of 5');
+		expect(state.priority).toBe('polite');
+		expect(state.version).toBe(1);
+	});
+
+	it('announces an assertive message', () => {
+		useAnnouncerStore.getState().announce('Error occurred', 'assertive');
+		const state = useAnnouncerStore.getState();
+		expect(state.message).toBe('Error occurred');
+		expect(state.priority).toBe('assertive');
+	});
+
+	it('increments version on each announcement', () => {
+		const store = useAnnouncerStore.getState();
+		store.announce('First');
+		store.announce('Second');
+		expect(useAnnouncerStore.getState().version).toBe(2);
+	});
+
+	it('clears message and resets version', () => {
+		useAnnouncerStore.getState().announce('Hello');
+		useAnnouncerStore.getState().clear();
+		const state = useAnnouncerStore.getState();
+		expect(state.message).toBe('');
+		expect(state.version).toBe(0);
+	});
+
+	it('exports convenience announce function', () => {
+		announce('Convenience message', 'assertive');
+		const state = useAnnouncerStore.getState();
+		expect(state.message).toBe('Convenience message');
+		expect(state.priority).toBe('assertive');
+	});
+
+	it('defaults to polite priority', () => {
+		announce('Default priority');
+		expect(useAnnouncerStore.getState().priority).toBe('polite');
+	});
+});

--- a/src/lib/stores/announcer-store.ts
+++ b/src/lib/stores/announcer-store.ts
@@ -1,0 +1,44 @@
+/**
+ * Store for screen reader announcements.
+ *
+ * Provides a centralized way to announce messages to
+ * assistive technologies via ARIA live regions.
+ *
+ * Spec reference: Section 11 (Accessibility Requirements)
+ */
+
+import { create } from 'zustand';
+
+export type AnnouncerPriority = 'polite' | 'assertive';
+
+export interface AnnouncerState {
+	message: string;
+	priority: AnnouncerPriority;
+	/** Incrementing counter to force re-announcements of identical messages */
+	version: number;
+}
+
+export interface AnnouncerActions {
+	announce: (message: string, priority?: AnnouncerPriority) => void;
+	clear: () => void;
+}
+
+export const useAnnouncerStore = create<AnnouncerState & AnnouncerActions>((set) => ({
+	message: '',
+	priority: 'polite',
+	version: 0,
+
+	announce: (message, priority = 'polite') =>
+		set((state) => ({
+			message,
+			priority,
+			version: state.version + 1,
+		})),
+
+	clear: () => set({ message: '', version: 0 }),
+}));
+
+/** Convenience function for announcing from outside React components */
+export function announce(message: string, priority: AnnouncerPriority = 'polite'): void {
+	useAnnouncerStore.getState().announce(message, priority);
+}


### PR DESCRIPTION
## Summary
- Add `ScreenReaderAnnouncer` component with polite/assertive ARIA live regions for dynamic content announcements
- Add `SkipToContent` component for keyboard navigation bypass
- Add `CanvasA11yLayer` — parallel DOM that mirrors canvas scene graph with element positions and selection state for screen readers
- Add `useReducedMotion` hook detecting `prefers-reduced-motion` media query
- Add `usePlaybackAnnouncer` hook announcing play/pause/stop state changes to screen readers
- Add `AnnouncerStore` (Zustand) for centralized screen reader message management
- Add CSS focus indicators (`focus-visible` with 2px ring outline) globally
- Add `prefers-reduced-motion` CSS that disables all animations/transitions
- Add high contrast mode CSS variables (7:1 WCAG AAA ratios)
- Add `.sr-only` utility class for visually hidden content
- Update `EditorLayout` to use semantic `<main>` element with `id="main-content"`
- Integrate `SkipToContent` and `ScreenReaderAnnouncer` into root layout
- Integrate `CanvasA11yLayer` into `PixiCanvas` component

## Test plan
- [x] AnnouncerStore: 7 tests (announce, clear, priority, version increment)
- [x] ScreenReaderAnnouncer: 5 tests (ARIA live regions, aria-atomic, sr-only)
- [x] SkipToContent: 3 tests (renders link, href, element type)
- [x] CanvasA11yLayer: 7 tests (region, element count, selection, positions)
- [x] useReducedMotion: 4 tests (default, preference detection, listener lifecycle)
- [x] usePlaybackAnnouncer: 4 tests (idle skip, play/pause/stop announcements)
- [x] All 1727 tests passing
- [x] TypeScript strict mode passes
- [x] Biome lint/format clean

Closes #62

🤖 Generated with [Claude Code](https://claude.com/claude-code)