### PR TITLE
feat: set up CI/CD pipeline with GitHub Actions (#63)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,147 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  NODE_VERSION: '22'
+  PNPM_VERSION: '10'
+
+jobs:
+  lint:
+    name: Lint & Format
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Biome check (lint + format)
+        run: pnpm biome check .
+
+  type-check:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: TypeScript type check
+        run: pnpm tsc --noEmit
+
+  test:
+    name: Unit & Integration Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Run Vitest with coverage
+        run: pnpm vitest run --coverage
+
+      - name: Upload coverage
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage/
+          retention-days: 7
+
+  e2e:
+    name: E2E Tests
+    runs-on: ubuntu-latest
+    needs: [lint, type-check]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        run: npx playwright install --with-deps chromium firefox webkit
+
+      - name: Build application
+        run: pnpm next build
+
+      - name: Run Playwright tests
+        run: pnpm playwright test
+
+      - name: Upload Playwright report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-report
+          path: playwright-report/
+          retention-days: 7
+
+  build:
+    name: Production Build
+    runs-on: ubuntu-latest
+    needs: [lint, type-check, test]
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: ${{ env.PNPM_VERSION }}
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: ${{ env.NODE_VERSION }}
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Build Next.js application
+        run: pnpm next build
+
+      - name: Upload build artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: next-build
+          path: .next/
+          retention-days: 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,93 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: deploy-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  VERCEL_ORG_ID: ${{ secrets.VERCEL_ORG_ID }}
+  VERCEL_PROJECT_ID: ${{ secrets.VERCEL_PROJECT_ID }}
+
+jobs:
+  deploy-preview:
+    name: Deploy Preview
+    if: github.event_name == 'pull_request'
+    runs-on: ubuntu-latest
+    environment:
+      name: preview
+      url: ${{ steps.deploy.outputs.url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: '10'
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Install Vercel CLI
+        run: pnpm add -g vercel
+
+      - name: Pull Vercel environment
+        run: vercel pull --yes --environment=preview --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build project
+        run: vercel build --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy to Vercel (preview)
+        id: deploy
+        run: echo "url=$(vercel deploy --prebuilt --token=${{ secrets.VERCEL_TOKEN }})" >> "$GITHUB_OUTPUT"
+
+  deploy-production:
+    name: Deploy Production
+    if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+    runs-on: ubuntu-latest
+    environment:
+      name: production
+      url: ${{ steps.deploy.outputs.url }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: '10'
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Install Vercel CLI
+        run: pnpm add -g vercel
+
+      - name: Pull Vercel environment
+        run: vercel pull --yes --environment=production --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Build project
+        run: vercel build --prod --token=${{ secrets.VERCEL_TOKEN }}
+
+      - name: Deploy to Vercel (production)
+        id: deploy
+        run: echo "url=$(vercel deploy --prebuilt --prod --token=${{ secrets.VERCEL_TOKEN }})" >> "$GITHUB_OUTPUT"
+
+      - name: Upload Sentry source maps
+        if: success()
+        run: npx @sentry/cli releases files "$COMMIT_SHA" upload-sourcemaps .next/
+        env:
+          COMMIT_SHA: ${{ github.sha }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
+          SENTRY_PROJECT: ${{ secrets.SENTRY_PROJECT }}

--- a/tests/integration/ci-config.test.ts
+++ b/tests/integration/ci-config.test.ts
@@ -1,0 +1,69 @@
+/**
+ * Tests for CI/CD pipeline configuration.
+ *
+ * Validates that workflow files exist and contain
+ * expected pipeline stages and toolchain versions.
+ */
+
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+
+const ROOT = resolve(__dirname, '../..');
+
+function readWorkflow(name: string): string {
+	return readFileSync(resolve(ROOT, `.github/workflows/${name}`), 'utf-8');
+}
+
+describe('CI pipeline configuration', () => {
+	it('ci.yml workflow file exists', () => {
+		const content = readWorkflow('ci.yml');
+		expect(content.length).toBeGreaterThan(0);
+	});
+
+	it('ci.yml triggers on push and pull_request', () => {
+		const content = readWorkflow('ci.yml');
+		expect(content).toContain('push:');
+		expect(content).toContain('pull_request:');
+	});
+
+	it('ci.yml uses Node.js 22', () => {
+		const content = readWorkflow('ci.yml');
+		expect(content).toContain('22');
+	});
+
+	it('ci.yml uses pnpm', () => {
+		const content = readWorkflow('ci.yml');
+		expect(content).toContain('pnpm');
+	});
+
+	it('ci.yml includes lint step', () => {
+		const content = readWorkflow('ci.yml');
+		expect(content).toContain('biome');
+	});
+
+	it('ci.yml includes type-check step', () => {
+		const content = readWorkflow('ci.yml');
+		expect(content).toContain('tsc');
+	});
+
+	it('ci.yml includes test step', () => {
+		const content = readWorkflow('ci.yml');
+		expect(content).toContain('vitest');
+	});
+
+	it('ci.yml includes build step', () => {
+		const content = readWorkflow('ci.yml');
+		expect(content).toContain('next build');
+	});
+
+	it('deploy.yml workflow file exists', () => {
+		const content = readWorkflow('deploy.yml');
+		expect(content.length).toBeGreaterThan(0);
+	});
+
+	it('deploy.yml references Vercel', () => {
+		const content = readWorkflow('deploy.yml');
+		expect(content).toContain('vercel');
+	});
+});


### PR DESCRIPTION
## Summary
- Add `.github/workflows/ci.yml` — CI pipeline with 5 parallel/sequential jobs:
  - **Lint** (Biome 2.3+), **Type Check** (tsc), **Test** (Vitest + coverage) run in parallel
  - **E2E** (Playwright on Chrome/Firefox/Safari) runs after lint + type-check
  - **Build** (Next.js production) runs after lint + type-check + test
- Add `.github/workflows/deploy.yml` — Vercel deployment:
  - Preview deployments on pull requests
  - Production deployments on push to main
  - Sentry source map uploads on production deploy
- Toolchain pinned: Node.js 22 LTS, pnpm 10.x
- Concurrency groups prevent duplicate runs on same branch

## Test plan
- [x] CI config tests: 10 tests validating workflow files (existence, triggers, tools, stages)
- [x] All 1737 tests passing
- [x] TypeScript strict mode passes
- [x] Biome lint/format clean

Closes #63

🤖 Generated with [Claude Code](https://claude.com/claude-code)